### PR TITLE
Add marketplace.json for Claude Code Marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "pua-skills",
+  "description": "PUA Debugging Motivator for Claude Code -- forces AI to exhaust all solutions before giving up, using Chinese tech giant corporate rhetoric",
+  "owner": {
+    "name": "探微安全实验室",
+    "url": "https://github.com/tanweai"
+  },
+  "plugins": [
+    {
+      "name": "pua",
+      "description": "PUA Debugging Motivator -- forces Claude Code to exhaust all solutions before giving up, using corporate PUA rhetoric from Chinese tech giants (Alibaba, ByteDance, Huawei, Tencent, Meituan)",
+      "version": "1.0.0",
+      "source": "./",
+      "author": {
+        "name": "探微安全实验室",
+        "url": "https://github.com/tanweai"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
  ## Summary

  Add `marketplace.json` to enable PUA Debugging Motivator installation via Claude Code Marketplace.

  ## Changes

  - Create `.claude-plugin/marketplace.json`
  - Follow superpowers project marketplace format specification
  - Include plugin metadata: name, description, version, author info

  ## Expected Result

  Users can install directly via:

  ```bash
  claude plugin marketplace add tanweai/pua
  claude plugin install pua
  ```