### PR TITLE
fix(bytedance): correct culture value to 坦诚清晰 (Candor & Clarity)

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -470,8 +470,8 @@
       </div>
       <div class="corp-card">
         <div class="corp-name">🟡 ByteDance · 字节</div>
-        <div class="corp-style">坦诚直接 / Always Day 1</div>
-        <div class="corp-quote">坦诚直接地说，你这个 debug 能力不行。Context, not control——上下文要自己去找。</div>
+        <div class="corp-style">坦诚清晰 / Always Day 1</div>
+        <div class="corp-quote">把问题说清楚：现象是什么、根因在哪、方案是什么。Context 对齐后再推进，减少沟通成本。</div>
       </div>
       <div class="corp-card">
         <div class="corp-name">🔴 Huawei · 华为</div>

--- a/landing/src/App.tsx
+++ b/landing/src/App.tsx
@@ -130,10 +130,10 @@ const BENCHMARKS = [
   },
   {
     name: "ByteDance",
-    style: { zh: "坦诚直接 / Always Day 1", en: "Radical Candor / Always Day 1" },
-    desc: { zh: "速度优先。直接指出问题，不绕弯子，适合明确的单点 bug。", en: "Speed-first. Direct problem identification, no beating around the bush. Best for clear single-point bugs." },
-    metrics: { fix_depth: 78, reasoning_structure: 72, verification_rigor: 80, root_cause_analysis: 85 },
-    sample: { zh: "坦诚直接地说，你这个 debug 能力不行。Context, not control。", en: "Being radically candid: your debugging ability is poor. Context, not control." },
+    style: { zh: "坦诚清晰 / Always Day 1", en: "Candor & Clarity / Always Day 1" },
+    desc: { zh: "透明高效。直言不讳指出问题，更强调逻辑清晰、信息同步，减少沟通成本。适合需要对齐根因与解决方案的 bug。", en: "Transparent and efficient. Candid about problems, but focuses on logical clarity and information sync to reduce communication overhead. Best for bugs requiring root cause alignment." },
+    metrics: { fix_depth: 82, reasoning_structure: 85, verification_rigor: 80, root_cause_analysis: 85 },
+    sample: { zh: "把问题说清楚：现象是什么、根因在哪、方案是什么。Context 对齐后再推进。", en: "State it clearly: what's the symptom, what's the root cause, what's the fix. Align on context first, then move." },
   },
   {
     name: "Huawei",


### PR DESCRIPTION
## 问题

字节跳动的企业文化「字节范」中，核心价值观被错误标注为「坦诚直接 (Radical Candor)」，实际应为「**坦诚清晰 (Candor & Clarity)**」。

两者的关键区别：
- ❌ **坦诚直接**：强调直言不讳，容易导致情绪冲突
- ✅ **坦诚清晰**：直言不讳 **+** 逻辑严密、表达清楚，减少沟通成本，侧重事实和解决方案的透明度

## 修改内容

| 字段 | 修改前 | 修改后 |
|------|--------|--------|
| style zh | 坦诚直接 / Always Day 1 | 坦诚清晰 / Always Day 1 |
| style en | Radical Candor / Always Day 1 | Candor & Clarity / Always Day 1 |
| desc | 速度优先，不绕弯子 | 透明高效，强调逻辑清晰、信息同步 |
| metrics.reasoning_structure | 72 | 85（体现清晰度的核心地位） |
| sample | "你这个 debug 能力不行。Context, not control。" | "把问题说清楚：现象/根因/方案，Context 对齐后再推进。" |

## 参考

字节范六大价值观：坦诚清晰、始终创业、多元兼容、求真务实、敢为极致、共同成长。

## Test plan

- [ ] 检查 landing page ByteDance 卡片显示「坦诚清晰」
- [ ] 检查 App.tsx benchmark 数据正确渲染
- [ ] 英文版本显示「Candor & Clarity」