### PR TITLE
docs: add Vercel Skills install instructions for Codex

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -207,6 +207,21 @@ git clone https://github.com/tanweai/pua.git ~/.claude/plugins/pua
 
 Codex CLIは同じAgent Skillsオープンスタンダード（SKILL.md）を使用。Codex版はCodexの長さ制限に対応した短縮descriptionを使用：
 
+**方法1：Vercel Skills CLIでインストール（推奨）**
+
+```bash
+npx skills add https://github.com/tanweai/pua --skill pua-ja
+
+# /pua コマンドが必要な場合
+mkdir -p ~/.codex/prompts
+curl -o ~/.codex/prompts/pua.md \
+  https://raw.githubusercontent.com/tanweai/pua/main/commands/pua.md
+```
+
+現在のCodexセッションで新しいskillがすぐに反映されない場合は、Codexを再起動してください。
+
+**方法2：手動インストール**
+
 ```bash
 mkdir -p ~/.codex/skills/pua-ja
 curl -o ~/.codex/skills/pua-ja/SKILL.md \

--- a/README.md
+++ b/README.md
@@ -220,6 +220,21 @@ git clone https://github.com/tanweai/pua.git ~/.claude/plugins/pua
 
 Codex CLI uses the same Agent Skills open standard (SKILL.md). The Codex version uses a condensed description to fit Codex's length limits:
 
+**Option 1: Install with Vercel Skills CLI (recommended)**
+
+```bash
+npx skills add https://github.com/tanweai/pua --skill pua
+
+# If you need the /pua command
+mkdir -p ~/.codex/prompts
+curl -o ~/.codex/prompts/pua.md \
+  https://raw.githubusercontent.com/tanweai/pua/main/commands/pua.md
+```
+
+If the current Codex session does not pick up the new skill immediately, restart Codex.
+
+**Option 2: Manual install**
+
 ```bash
 mkdir -p ~/.codex/skills/pua
 curl -o ~/.codex/skills/pua/SKILL.md \

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -206,6 +206,21 @@ git clone https://github.com/tanweai/pua.git ~/.claude/plugins/pua
 
 Codex CLI 使用相同的 Agent Skills 开放标准（SKILL.md）。Codex 版本使用精简的 description 以兼容 Codex 的长度限制：
 
+**方式一：通过 Vercel Skills CLI 安装（推荐）**
+
+```bash
+npx skills add https://github.com/tanweai/pua --skill pua
+
+# 如果需要 /pua 指令的话
+mkdir -p ~/.codex/prompts
+curl -o ~/.codex/prompts/pua.md \
+  https://raw.githubusercontent.com/tanweai/pua/main/commands/pua.md
+```
+
+如果当前 Codex 会话没有立即识别到新 skill，重启 Codex 即可。
+
+**方式二：手动安装**
+
 ```bash
 mkdir -p ~/.codex/skills/pua
 curl -o ~/.codex/skills/pua/SKILL.md \


### PR DESCRIPTION
## Summary
- add a Vercel Skills CLI install option to the Codex section in the English README
- mirror the same instructions in the Simplified Chinese and Japanese READMEs
- note that restarting Codex may be required for the skill to appear in the current session

## Testing
- docs only; verified the referenced Codex skill paths and command file paths in the repo