### PR TITLE
feat(codex): add INSTALL.md one-command install and improve Codex docs

### DIFF
--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -1,0 +1,106 @@
+# Installing PUA Skill for Codex
+
+Force AI to exhaust every possible solution before giving up. Installs via native skill discovery (`~/.codex/skills/`).
+
+## Prerequisites
+
+- Git
+
+## Installation
+
+### macOS / Linux
+
+```bash
+# 1. Clone the repo
+git clone https://github.com/tanweai/pua.git ~/.codex/pua
+
+# 2. Create skill symlink (enables auto-discovery)
+mkdir -p ~/.codex/skills
+ln -s ~/.codex/pua/codex/pua ~/.codex/skills/pua
+
+# 3. Install /prompts:pua trigger
+mkdir -p ~/.codex/prompts
+ln -s ~/.codex/pua/commands/pua.md ~/.codex/prompts/pua.md
+
+# 4. Restart Codex
+```
+
+### Windows (PowerShell)
+
+```powershell
+# 1. Clone the repo
+git clone https://github.com/tanweai/pua.git "$env:USERPROFILE\.codex\pua"
+
+# 2. Create skill junction (enables auto-discovery)
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.codex\skills"
+cmd /c mklink /J "$env:USERPROFILE\.codex\skills\pua" "$env:USERPROFILE\.codex\pua\codex\pua"
+
+# 3. Install /prompts:pua trigger
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.codex\prompts"
+cmd /c mklink "$env:USERPROFILE\.codex\prompts\pua.md" "$env:USERPROFILE\.codex\pua\commands\pua.md"
+
+# 4. Restart Codex
+```
+
+## Verify
+
+Type `$pua` in a Codex conversation. If the skill is loaded, you'll see it activate.
+
+Or check directly:
+```bash
+# macOS / Linux
+ls ~/.codex/skills/pua/SKILL.md
+
+# Windows PowerShell
+Test-Path "$env:USERPROFILE\.codex\skills\pua\SKILL.md"
+```
+
+## Trigger Methods
+
+| Method | Command | Requires |
+|--------|---------|----------|
+| Auto trigger | No action needed, matches by description | SKILL.md |
+| Direct call | Type `$pua` in conversation | SKILL.md |
+| Manual prompt | Type `/prompts:pua` in conversation | SKILL.md + prompts/pua.md |
+
+## Language Variants
+
+| Language | Skill path |
+|----------|------------|
+| 🇨🇳 Chinese (default) | `codex/pua/SKILL.md` |
+| 🇺🇸 English (PIP) | `codex/pua-en/SKILL.md` |
+| 🇯🇵 Japanese | `codex/pua-ja/SKILL.md` |
+
+To install a different language variant, replace `pua` with `pua-en` or `pua-ja` in the symlink/junction step:
+
+```bash
+# Example: English variant (macOS/Linux)
+ln -s ~/.codex/pua/codex/pua-en ~/.codex/skills/pua-en
+```
+
+## Update
+
+```bash
+cd ~/.codex/pua
+git pull
+```
+
+The symlink/junction automatically picks up the latest version — no reinstall needed.
+
+## Uninstall
+
+### macOS / Linux
+
+```bash
+rm ~/.codex/skills/pua
+rm ~/.codex/prompts/pua.md
+rm -rf ~/.codex/pua
+```
+
+### Windows (PowerShell)
+
+```powershell
+Remove-Item "$env:USERPROFILE\.codex\skills\pua"
+Remove-Item "$env:USERPROFILE\.codex\prompts\pua.md"
+Remove-Item -Recurse "$env:USERPROFILE\.codex\pua"
+```

--- a/README.ja.md
+++ b/README.ja.md
@@ -208,14 +208,52 @@ git clone https://github.com/tanweai/pua.git ~/.claude/plugins/pua
 
 Codex CLIは同じAgent Skillsオープンスタンダード（SKILL.md）を使用。Codex版はCodexの長さ制限に対応した短縮descriptionを使用：
 
+**推奨：一括インストール（git clone + シンボリックリンク、`git pull` での更新に対応）**
+
+Codexに実行させる：
+```
+Fetch and follow instructions from https://raw.githubusercontent.com/tanweai/pua/main/.codex/INSTALL.md
+```
+
+**手動インストール：**
+
 ```bash
 mkdir -p ~/.codex/skills/pua-ja
 curl -o ~/.codex/skills/pua-ja/SKILL.md \
   https://raw.githubusercontent.com/tanweai/pua/main/codex/pua-ja/SKILL.md
 
-# /puaコマンドが必要な場合
 mkdir -p ~/.codex/prompts
 curl -o ~/.codex/prompts/pua.md \
+  https://raw.githubusercontent.com/tanweai/pua/main/commands/pua.md
+```
+
+**Windows ユーザー**（PowerShell、UTF-8エンコーディングを確実に）：
+
+```powershell
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.codex\skills\pua-ja"
+$url = "https://raw.githubusercontent.com/tanweai/pua/main/codex/pua-ja/SKILL.md"
+$dest = "$env:USERPROFILE\.codex\skills\pua-ja\SKILL.md"
+$content = (Invoke-WebRequest $url).Content
+[System.IO.File]::WriteAllText($dest, $content, (New-Object System.Text.UTF8Encoding $false))
+```
+
+**トリガー方法：**
+
+| 方法 | コマンド | 必要なもの |
+|------|---------|-----------|
+| 自動トリガー | 操作不要、descriptionによるマッチング | SKILL.md |
+| 直接呼び出し | 対話で `$pua` と入力 | SKILL.md |
+| 手動プロンプト | 対話で `/prompts:pua` と入力 | SKILL.md + prompts/pua.md |
+
+プロジェクトレベルインストール（現在のプロジェクトのみ有効）：
+
+```bash
+mkdir -p .agents/skills/pua-ja
+curl -o .agents/skills/pua-ja/SKILL.md \
+  https://raw.githubusercontent.com/tanweai/pua/main/codex/pua-ja/SKILL.md
+
+mkdir -p .agents/prompts
+curl -o .agents/prompts/pua.md \
   https://raw.githubusercontent.com/tanweai/pua/main/commands/pua.md
 ```
 

--- a/README.md
+++ b/README.md
@@ -223,16 +223,42 @@ git clone https://github.com/tanweai/pua.git ~/.claude/plugins/pua
 
 Codex CLI uses the same Agent Skills open standard (SKILL.md). The Codex version uses a condensed description to fit Codex's length limits:
 
+**Recommended: One-command install (git clone + symlink, supports `git pull` updates)**
+
+Ask Codex to run:
+```
+Fetch and follow instructions from https://raw.githubusercontent.com/tanweai/pua/main/.codex/INSTALL.md
+```
+
+**Manual install:**
+
 ```bash
 mkdir -p ~/.codex/skills/pua
 curl -o ~/.codex/skills/pua/SKILL.md \
   https://raw.githubusercontent.com/tanweai/pua/main/codex/pua/SKILL.md
 
-# If you need the /pua command
 mkdir -p ~/.codex/prompts
 curl -o ~/.codex/prompts/pua.md \
   https://raw.githubusercontent.com/tanweai/pua/main/commands/pua.md
 ```
+
+**Windows users** (PowerShell, ensures correct UTF-8 encoding):
+
+```powershell
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.codex\skills\pua"
+$url = "https://raw.githubusercontent.com/tanweai/pua/main/codex/pua/SKILL.md"
+$dest = "$env:USERPROFILE\.codex\skills\pua\SKILL.md"
+$content = (Invoke-WebRequest $url).Content
+[System.IO.File]::WriteAllText($dest, $content, (New-Object System.Text.UTF8Encoding $false))
+```
+
+**Trigger methods:**
+
+| Method | Command | Requires |
+|--------|---------|----------|
+| Auto trigger | No action needed, matches by description | SKILL.md |
+| Direct call | Type `$pua` in conversation | SKILL.md |
+| Manual prompt | Type `/prompts:pua` in conversation | SKILL.md + prompts/pua.md |
 
 Project-level install (current project only):
 
@@ -241,7 +267,6 @@ mkdir -p .agents/skills/pua
 curl -o .agents/skills/pua/SKILL.md \
   https://raw.githubusercontent.com/tanweai/pua/main/codex/pua/SKILL.md
 
-# If you need the /pua command
 mkdir -p .agents/prompts
 curl -o .agents/prompts/pua.md \
   https://raw.githubusercontent.com/tanweai/pua/main/commands/pua.md

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -207,16 +207,42 @@ git clone https://github.com/tanweai/pua.git ~/.claude/plugins/pua
 
 Codex CLI 使用相同的 Agent Skills 开放标准（SKILL.md）。Codex 版本使用精简的 description 以兼容 Codex 的长度限制：
 
+**推荐：一键安装（git clone + symlink，支持 `git pull` 更新）**
+
+让 Codex 执行：
+```
+Fetch and follow instructions from https://raw.githubusercontent.com/tanweai/pua/main/.codex/INSTALL.md
+```
+
+**手动安装：**
+
 ```bash
 mkdir -p ~/.codex/skills/pua
 curl -o ~/.codex/skills/pua/SKILL.md \
   https://raw.githubusercontent.com/tanweai/pua/main/codex/pua/SKILL.md
-  
-# 如果需要 /pua 指令的话
+
 mkdir -p ~/.codex/prompts
 curl -o ~/.codex/prompts/pua.md \
   https://raw.githubusercontent.com/tanweai/pua/main/commands/pua.md
 ```
+
+**Windows 用户**（PowerShell，确保中文正确写入）：
+
+```powershell
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.codex\skills\pua"
+$url = "https://raw.githubusercontent.com/tanweai/pua/main/codex/pua/SKILL.md"
+$dest = "$env:USERPROFILE\.codex\skills\pua\SKILL.md"
+$content = (Invoke-WebRequest $url).Content
+[System.IO.File]::WriteAllText($dest, $content, (New-Object System.Text.UTF8Encoding $false))
+```
+
+**触发方式：**
+
+| 方式 | 命令 | 需要 |
+|------|------|------|
+| 自动触发 | 无需操作，根据 description 匹配 | SKILL.md |
+| 直接调用 | 对话中输入 `$pua` | SKILL.md |
+| 手动 prompt | 对话中输入 `/prompts:pua` | SKILL.md + prompts/pua.md |
 
 项目级安装（仅当前项目生效）：
 
@@ -225,7 +251,6 @@ mkdir -p .agents/skills/pua
 curl -o .agents/skills/pua/SKILL.md \
   https://raw.githubusercontent.com/tanweai/pua/main/codex/pua/SKILL.md
 
-# 如果需要 /pua 指令的话
 mkdir -p .agents/prompts
 curl -o .agents/prompts/pua.md \
   https://raw.githubusercontent.com/tanweai/pua/main/commands/pua.md


### PR DESCRIPTION
## Summary

- Add `.codex/INSTALL.md` with cross-platform one-command install guide (git clone + symlink/junction)
- Install via symlink means `git pull` auto-updates without reinstall
- Document all 3 Codex trigger methods: auto (description matching), `$pua` (direct), `/prompts:pua` (manual prompt)
- Add Windows PowerShell install with correct UTF-8 encoding (no BOM) to prevent mojibake
- Fix `/pua` → `/prompts:pua` across all 3 READMEs
- Add project-level install with prompts to Japanese README

## Test plan

- [ ] Ask Codex to `Fetch and follow instructions from https://raw.githubusercontent.com/tanweai/pua/main/.codex/INSTALL.md` and verify it clones and symlinks correctly
- [ ] Type `$pua` in Codex — skill should activate
- [ ] Type `/prompts:pua` in Codex — prompt should load
- [ ] Verify Windows PowerShell install writes SKILL.md without BOM
- [ ] Verify `git pull` in `~/.codex/pua` picks up latest without relinking

Closes #33