### PR TITLE
fix(blog): blog index page nav lang-i CSS and sl() function missing

### DIFF
--- a/landing/dist/blog/index.html
+++ b/landing/dist/blog/index.html
@@ -35,6 +35,7 @@
     .lsw{display:flex;background:var(--bg-card);border-radius:6px;padding:2px;border:1px solid var(--border)}
     .lsw button{background:none;border:none;color:var(--text-m);padding:3px 9px;border-radius:4px;cursor:pointer;font-size:.65rem;font-weight:600;font-family:inherit;transition:all .2s}
     .lsw button.on{background:var(--brand);color:#fff}
+    .lang-i{display:none}.lang-i.show{display:inline}
   </style>
 </head>
 <body>
@@ -94,7 +95,7 @@
 <script>
 function sl(l){
   document.querySelectorAll('.lsw button').forEach(function(b){b.classList.toggle('on',b.textContent.trim()===(l==='zh'?'中':'EN'))});
-  document.querySelectorAll('.lang').forEach(function(el){el.classList.toggle('show',el.dataset.lang===l)});
+  document.querySelectorAll('.lang,.lang-i').forEach(function(el){el.classList.toggle('show',el.dataset.lang===l)});
 }
 </script>
 </body>


### PR DESCRIPTION
## Problem

`landing/dist/blog/index.html` was missing two things added to all other pages:

1. CSS: `.lang-i{display:none}.lang-i.show{display:inline}` — without it, both ZH and EN spans in the Guide nav link were visible simultaneously
2. `sl()` function only toggled `.lang` divs, not `.lang-i` spans — Guide link text didn't change when switching language

`blog/emotion-persona-prompting.html` already had both fixes from a previous commit.

## Fix

- Added `.lang-i` CSS rule
- Extended `sl()` to handle `.lang,.lang-i` together (same pattern as all other pages)