### PR TITLE
fix: add rate limiting and field size limits to feedback endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,3 +715,25 @@ MIT
 ## Credits
 
 By [TanWei Security Lab](https://github.com/tanweai) — making AI try harder, one PUA at a time.
+
+## Security Features (v2.0+)
+
+The feedback endpoint now includes:
+
+- **Rate Limiting**: Max 5 requests per IP per hour
+- **Field Size Limits**: 
+  - `session_data`: 10KB max
+  - `task_summary`: 1KB max
+  - `rating`: 50 chars max
+  - `flavor`: 100 chars max
+
+To enable rate limiting, add a KV namespace binding:
+
+```toml
+# wrangler.toml
+[[kv_namespaces]]
+binding = "RATE_LIMITER"
+id = "your-kv-namespace-id"
+```
+
+Without KV binding, the endpoint still works but without rate limiting.

--- a/landing/functions/api/feedback.ts
+++ b/landing/functions/api/feedback.ts
@@ -1,11 +1,49 @@
 interface Env {
   DB: D1Database
+  RATE_LIMITER: KVNamespace
 }
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type",
+  "Access-Control-Allow-Headers": "Content-Type, X-Feedback-Token",
+}
+
+// Rate limit: max 5 requests per IP per hour
+const RATE_LIMIT_MAX = 5
+const RATE_LIMIT_WINDOW = 3600 // 1 hour in seconds
+
+// Max sizes for fields
+const MAX_SESSION_DATA_SIZE = 10000 // 10KB max
+const MAX_TASK_SUMMARY_SIZE = 1000
+
+async function isRateLimited(ip: string, env: Env): Promise<boolean> {
+  const key = `feedback:${ip}`
+  const count = await env.RATE_LIMITER.get(key)
+  const currentCount = count ? parseInt(count, 10) : 0
+  
+  if (currentCount >= RATE_LIMIT_MAX) {
+    return true
+  }
+  
+  // Increment counter
+  await env.RATE_LIMITER.put(key, String(currentCount + 1), {
+    expirationTtl: RATE_LIMIT_WINDOW
+  })
+  
+  return false
+}
+
+function getClientIP(request: Request): string {
+  // Try CF-Connecting-IP first (Cloudflare)
+  const cfIP = request.headers.get("CF-Connecting-IP")
+  if (cfIP) return cfIP
+  
+  // Fallback to X-Forwarded-For
+  const xff = request.headers.get("X-Forwarded-For")
+  if (xff) return xff.split(",")[0].trim()
+  
+  return "unknown"
 }
 
 export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
@@ -18,6 +56,18 @@ export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
   const isPost = request.method === "POST" || hasJsonContentType
 
   if (isPost) {
+    // Rate limiting
+    const clientIP = getClientIP(request)
+    if (env.RATE_LIMITER) {
+      const limited = await isRateLimited(clientIP, env)
+      if (limited) {
+        return Response.json(
+          { error: "Rate limit exceeded. Please try again later." },
+          { status: 429, headers: corsHeaders }
+        )
+      }
+    }
+    
     // Try to read body — custom domain may strip it
     let bodyText: string | null = null
     try { bodyText = await request.text() } catch {}
@@ -38,17 +88,22 @@ export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
           return Response.json({ error: "rating is required" }, { status: 400, headers: corsHeaders })
         }
 
+        // Validate and sanitize field sizes
+        const rating = body.rating.slice(0, 50) // Limit rating length
+        const taskSummary = body.task_summary?.slice(0, MAX_TASK_SUMMARY_SIZE) || null
+        const sessionData = body.session_data?.slice(0, MAX_SESSION_DATA_SIZE) || null
+
         await env.DB.prepare(
           `INSERT INTO feedback (rating, task_summary, pua_level, pua_count, flavor, session_data, failure_count, ip_country)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
         )
           .bind(
-            body.rating,
-            body.task_summary || null,
+            rating,
+            taskSummary,
             body.pua_level || "L0",
             body.pua_count || 0,
-            body.flavor || "阿里",
-            body.session_data || null,
+            body.flavor?.slice(0, 100) || "阿里",
+            sessionData,
             body.failure_count || 0,
             request.headers.get("CF-IPCountry") || "unknown"
           )


### PR DESCRIPTION
Fixes #96

## Summary
Security hardening for the POST /api/feedback endpoint.

## Changes

1. **IP-based Rate Limiting** - Max 5 requests per IP per hour
2. **Field Size Limits** - Prevent storage exhaustion:
   - session_data: 10KB max
   - task_summary: 1KB max
   - rating: 50 chars max
   - flavor: 100 chars max
3. **Configuration** - Add KV namespace binding for rate limiter

## Backward Compatibility
- Existing clients continue to work
- No breaking changes to API contract
- Rate limiting is opt-in via KV binding