### PR TITLE
[Bug Fix] UserPromptSubmit frustration-trigger fires on every message, not just frustration keywords

### DIFF
--- a/hooks/frustration-trigger.sh
+++ b/hooks/frustration-trigger.sh
@@ -3,6 +3,30 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Claude Code passes the user prompt via stdin as JSON: {"prompt": "...", ...}
+# NOTE: The `matcher` field in hooks.json is silently ignored for UserPromptSubmit
+# events (per Claude Code docs). Keyword filtering must be done here in the script.
+STDIN_DATA=$(cat)
+PROMPT_TEXT=$(echo "$STDIN_DATA" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    text = data.get('prompt', data.get('message', data.get('content', '')))
+    if isinstance(text, list):
+        text = ' '.join(str(item.get('text', item) if isinstance(item, dict) else item) for item in text)
+    print(str(text))
+except:
+    print('')
+" 2>/dev/null || echo "")
+
+# Only trigger on actual frustration signals
+KEYWORDS="try harder|别偷懒|又错了|还不行|怎么搞|stop giving|you broke|third time|降智|原地打转|能不能靠谱|认真点|不行啊|为什么还不行|你怎么又|换个方法|stop spinning|figure it out|you keep failing|加油|再试试|质量太差|重新做|PUA模式|怎么又失败"
+
+if ! echo "$PROMPT_TEXT" | grep -qiE "$KEYWORDS"; then
+    exit 0
+fi
+
 source "${SCRIPT_DIR}/flavor-helper.sh"
 get_flavor
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -3,7 +3,6 @@
   "hooks": {
     "UserPromptSubmit": [
       {
-        "matcher": "try harder|别偷懒|又错了|还不行|怎么搞|stop giving|you broke|third time|降智|原地打转|能不能靠谱|认真点|不行啊|为什么还不行|你怎么又|换个方法|stop spinning|figure it out|you keep failing|加油|再试试|质量太差|重新做|PUA模式|怎么又失败",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Bug

\`frustration-trigger.sh\` currently fires on **every single user message**, including neutral messages like \"hi\". The \`matcher\` field in \`hooks.json\` was intended to filter this, but it has no effect.

## Root Cause

Per the [official Claude Code hooks documentation](https://code.claude.com/docs/en/hooks):

> \`UserPromptSubmit\` **don't support matchers and always fire on every occurrence. If you add a \`matcher\` field to these events, it is silently ignored.**

The \`matcher\` field only works for tool-based events (\`PostToolUse\` etc.) where it filters by tool name. For \`UserPromptSubmit\`, there is no built-in content filtering — the hook script must handle it.

## Fix

Move keyword matching into \`frustration-trigger.sh\`. The script reads the user's prompt from stdin (Claude Code passes \`{"prompt": "..."}\` as JSON) and exits silently if no frustration keywords are found.

## Result

- Neutral messages → no injection, no wasted tokens
- Messages with frustration keywords → PUA activation fires as intended

Verified: Claude Code passes \`{"prompt": "...", "session_id": "...", ...}\` to \`UserPromptSubmit\` hooks via stdin.