### PR TITLE
fix: 修复 /pua:off 无法禁用沮丧检测和失败升级 hook 的问题

### DIFF
--- a/hooks/failure-detector.sh
+++ b/hooks/failure-detector.sh
@@ -4,6 +4,15 @@
 
 set -euo pipefail
 
+# Respect /pua:off — skip injection when always_on is false
+PUA_CONFIG="${HOME:-~}/.pua/config.json"
+if [ -f "$PUA_CONFIG" ]; then
+  ALWAYS_ON=$(python3 -c "import json; print(json.load(open('$PUA_CONFIG')).get('always_on', True))" 2>/dev/null || echo "True")
+  if [ "$ALWAYS_ON" = "False" ]; then
+    exit 0
+  fi
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/flavor-helper.sh"
 get_flavor

--- a/hooks/frustration-trigger.sh
+++ b/hooks/frustration-trigger.sh
@@ -2,6 +2,15 @@
 # PUA UserPromptSubmit hook: inject flavor-aware PUA trigger on user frustration
 set -euo pipefail
 
+# Respect /pua:off — skip injection when always_on is false
+PUA_CONFIG="${HOME:-~}/.pua/config.json"
+if [ -f "$PUA_CONFIG" ]; then
+  ALWAYS_ON=$(python3 -c "import json; print(json.load(open('$PUA_CONFIG')).get('always_on', True))" 2>/dev/null || echo "True")
+  if [ "$ALWAYS_ON" = "False" ]; then
+    exit 0
+  fi
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/flavor-helper.sh"
 get_flavor


### PR DESCRIPTION
当 always_on 为 false 时（即用户执行了 /pua:off），frustration-trigger.sh 和 failure-detector.sh 应跳过注入。此前这两个 hook 未检查配置状态，
在用户明确关闭 PUA 后仍会无条件注入内容。