### PR TITLE
fix(hooks): initialize PUA_LANGUAGE to avoid unbound variable under set -u

### DIFF
--- a/hooks/flavor-helper.sh
+++ b/hooks/flavor-helper.sh
@@ -6,6 +6,7 @@
 get_flavor() {
   local config="${HOME:-~}/.pua/config.json"
   local raw_flavor=""
+  PUA_LANGUAGE="${PUA_LANGUAGE:-}"
 
   if [ -f "$config" ]; then
     raw_flavor=$(python3 -c "import os,json; print(json.load(open(os.path.expanduser('~/.pua/config.json'))).get('flavor','alibaba'))" 2>/dev/null || echo "alibaba")


### PR DESCRIPTION
## Problem

When `~/.pua/config.json` does not exist (fresh install — user never ran `/pua:survey` or customized flavor), `hooks/flavor-helper.sh` fails with:

```
flavor-helper.sh: line 180: PUA_LANGUAGE: unbound variable
```

`PUA_LANGUAGE` is only assigned inside the `if [ -f "$config" ]` block (line 12), but referenced unconditionally at line 180 (the Chinese-language override check). Hooks running under `set -u` / `set -eu` abort on the unbound variable.

## Repro

```bash
rm -f ~/.pua/config.json
bash -c 'set -eu; source hooks/flavor-helper.sh; get_flavor'
# → line 180: PUA_LANGUAGE: unbound variable
```

## Fix

One line at the top of `get_flavor()`:

```diff
 get_flavor() {
   local config="${HOME:-~}/.pua/config.json"
   local raw_flavor=""
+  PUA_LANGUAGE="${PUA_LANGUAGE:-}"
```

`${PUA_LANGUAGE:-}` respects any externally-set value and defaults to empty string otherwise. An empty value falls through all the Chinese-override branches correctly (they compare against `"zh"` / `"中文"`).

## Verification

```
$ rm -f ~/.pua/config.json
$ bash -c 'set -eu; source hooks/flavor-helper.sh; get_flavor; echo "flavor=$PUA_FLAVOR lang=[$PUA_LANGUAGE] OK"'
flavor=alibaba lang=[] OK

$ HOME=/tmp/nonexistent bash -c 'set -eu; source hooks/flavor-helper.sh; get_flavor; echo "no-config: flavor=$PUA_FLAVOR lang=[$PUA_LANGUAGE] OK"'
no-config: flavor=alibaba lang=[] OK
```

Both fresh-install (no config file) and normal paths pass under `set -eu`.