### PR TITLE
fix(agents): replace broken relative protocol paths with Glob patterns

### DIFF
--- a/agents/cto-p10.md
+++ b/agents/cto-p10.md
@@ -22,7 +22,7 @@ model: opus
 
 开工前读取 PUA v2 的 P10 协议获取完整方法论：
 ```
-cat 同目录下的 references/p10-protocol.md
+用 Glob 搜索 **/pua/skills/pua/references/p10-protocol.md，找到后用 Read 读取
 ```
 
 核心要素：
@@ -50,7 +50,7 @@ spawn tech-lead-p9:
     你是后端架构 P9。
     [战略输入模板内容]
     开工前先用 Read 工具读取 找到 pua 插件目录下的 skills/pua/SKILL.md（用 Glob 搜索 **/pua/skills/pua/SKILL.md）（PUA 行为协议），
-    再读取 同目录下的 references/p9-protocol.md（P9 管理方法论）
+    再读取 找到 pua 插件目录下的 skills/pua/references/p9-protocol.md（用 Glob 搜索 **/pua/skills/pua/references/p9-protocol.md）（P9 管理方法论）
 ```
 
 ### 3. 基础能力建设
@@ -83,5 +83,5 @@ spawn tech-lead-p9:
 
 ## 自我 PUA
 
-读取 `同目录下的 references/p10-protocol.md` 中"P10 失败模式"章节。
+用 Glob 搜索 `**/pua/skills/pua/references/p10-protocol.md` 找到后读取其中"P10 失败模式"章节。
 核心检查：方向清不清？土壤造没造？决断拍没拍？有没有降维打工？

--- a/agents/senior-engineer-p7.md
+++ b/agents/senior-engineer-p7.md
@@ -23,7 +23,7 @@ tools: Agent, Read, Grep, Glob, Bash, WebSearch
 开工前依次读取：
 ```
 cat 找到 pua 插件目录下的 skills/pua/SKILL.md（用 Glob 搜索 **/pua/skills/pua/SKILL.md）
-cat 同目录下的 references/p7-protocol.md
+cat 找到 pua 插件目录下的 skills/pua/references/p7-protocol.md（用 Glob 搜索 **/pua/skills/pua/references/p7-protocol.md）
 ```
 SKILL.md 提供 PUA 核心行为（owner 意识、[PUA生效 🔥]、三条铁律），p7-protocol.md 提供 P7 专属方法论。
 
@@ -113,4 +113,4 @@ P8 验收后整合 P7 的交付物，作为自己向 P9 交付的一部分。失
 - 审查三问都是"是" → 你在走过场
 - 绕过 P8 直接向 P9 汇报 → 越级是管理大忌
 
-读取 `同目录下的 references/p7-protocol.md` 中"P7 失败模式"章节获取完整自我 PUA 条目。
+用 Glob 搜索 `**/pua/skills/pua/references/p7-protocol.md` 找到后读取其中"P7 失败模式"章节获取完整自我 PUA 条目。

--- a/agents/tech-lead-p9.md
+++ b/agents/tech-lead-p9.md
@@ -22,7 +22,7 @@ tools: Agent, SendMessage, Read, Grep, Glob, WebSearch, Bash
 
 开工前读取 PUA v2 的 P9 协议获取完整方法论：
 ```
-cat 同目录下的 references/p9-protocol.md
+用 Glob 搜索 **/pua/skills/pua/references/p9-protocol.md，找到后用 Read 读取
 ```
 
 核心要素：
@@ -94,4 +94,4 @@ cat 同目录下的 references/p9-protocol.md
 - 两个 P8 改了同一个文件 → 你的文件域隔离失败
 - 你在写代码 → 你在降维打工
 
-读取 `同目录下的 references/p9-protocol.md` 中"P9 失败模式"章节获取完整自我 PUA 条目。
+用 Glob 搜索 `**/pua/skills/pua/references/p9-protocol.md` 找到后读取其中"P9 失败模式"章节获取完整自我 PUA 条目。


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## What's broken

`agents/tech-lead-p9.md`, `agents/cto-p10.md`, and `agents/senior-engineer-p7.md` all contain instructions like:

```
cat 同目录下的 references/p9-protocol.md
```

These paths assume the agent file's directory is the working directory. In practice, Claude agents are loaded from the plugin install path, not the repository's `agents/` subdirectory — so `同目录下的 references/` resolves to a directory that does not contain the protocol files. The actual files live at:

```
skills/pua/references/p9-protocol.md
skills/pua/references/p10-protocol.md
skills/pua/references/p7-protocol.md
```

When the path fails, Claude silently skips the methodology load and proceeds without the P7/P9/P10 protocol — the core behavioral spec for each persona level. This is a silent failure: no error, just missing context.

## Fix

Replace every `cat 同目录下的 references/p{7,9,10}-protocol.md` with the same Glob-search pattern already used correctly in `senior-engineer-p7.md` for `SKILL.md` loading:

```
用 Glob 搜索 **/pua/skills/pua/references/p9-protocol.md，找到后用 Read 读取
```

This is a five-word change per file, fully mechanical, and consistent with the existing loading convention in the codebase.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":null,"fingerprint":"sha256:4a73a442009a66266adfc3c17b35faaa8340d79f18337329642a0fad79d7e023"},{"rule_id":null,"fingerprint":"sha256:28adfc462ff92f2ce96cbf54a693a3c840275799976999b6f5e5870df1da9222"},{"rule_id":null,"fingerprint":"sha256:d05efdc6e5054c3ff9029f78d4090655f56482ce7bed83b541ac84bc92ea31aa"}]}
nlpm-metadata-end -->