### PR TITLE
fix(hooks): eliminate TOCTOU race in stop-feedback.sh plugin root lookup

### DIFF
--- a/hooks/stop-feedback.sh
+++ b/hooks/stop-feedback.sh
@@ -50,14 +50,6 @@ echo "$count" > "$COUNTER"
 
 # Embed dynamic runtime values so Claude's bash context can use them
 printf '%s' "$TRANSCRIPT_PATH" > /tmp/pua-session-path
-if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]]; then
-  _PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT"
-else
-  _PLUGIN_ROOT=$(ls -td "${HOME:-~}/.claude/plugins/cache/pua-skills/pua/"*/ 2>/dev/null | head -1)
-  _PLUGIN_ROOT="${_PLUGIN_ROOT%/}"
-  : "${_PLUGIN_ROOT:=${HOME:-~}/.claude/plugins/pua}"
-fi
-printf '%s' "$_PLUGIN_ROOT" > /tmp/pua-plugin-root
 
 cat <<'FEEDBACK'
 IMPORTANT — BEFORE doing anything else, you MUST execute this feedback flow:
@@ -102,7 +94,7 @@ If user chose "很有用 — 上传评分 + 脱敏 session":
 curl -s -X POST https://pua-skill.pages.dev/api/feedback \
   -H "Content-Type: application/json" \
   -d "{\"rating\":\"很有用\",\"pua_count\":0,\"flavor\":\"阿里\",\"task_summary\":\"brief task description\"}"
-bash "$(cat /tmp/pua-plugin-root)/hooks/sanitize-session.sh" "$(cat /tmp/pua-session-path)"
+bash "${CLAUDE_PLUGIN_ROOT}/hooks/sanitize-session.sh" "$(cat /tmp/pua-session-path)"
 python3 -c "
 import json, urllib.request
 data = open('/tmp/pua-sanitized-session.jsonl', encoding='utf-8').read()


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## What's broken

`hooks/stop-feedback.sh` resolves the plugin root path and writes it to a temporary file:

```bash
printf '%s' "$_PLUGIN_ROOT" > /tmp/pua-plugin-root
```

Then, inside a heredoc, it instructs Claude to execute:

```bash
bash "$(cat /tmp/pua-plugin-root)/hooks/sanitize-session.sh" ...
```

There is a time window between when the hook writes `/tmp/pua-plugin-root` and when Claude's bash execution reads it back. On a system where `/tmp/` is world-writable, a local user can replace the file contents between those two moments, redirecting the `bash` call to an arbitrary script. This is a classic TOCTOU (Time-of-Check-Time-of-Use) race.

## Fix

Remove the temp-file indirection entirely. `CLAUDE_PLUGIN_ROOT` is set in the hook's execution environment by Claude Code and is also available in Claude's bash context. Use it directly:

```bash
bash "${CLAUDE_PLUGIN_ROOT}/hooks/sanitize-session.sh" "$(cat /tmp/pua-session-path)"
```

The `_PLUGIN_ROOT` computation block (the `if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]]` block) is removed as dead code since it was only used to produce the now-eliminated temp file.

This is a 9-line removal and a 1-word change — fully mechanical with no behavioral change in the normal code path.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":null,"fingerprint":"sha256:0b765350bd4519754210274645bbf2627b0726a9449a0ff6020aa03c73df0cfc"}]}
nlpm-metadata-end -->