### PR TITLE
fix(hooks): use hardcoded expanduser path in python3 always_on checks

### DIFF
--- a/hooks/failure-detector.sh
+++ b/hooks/failure-detector.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # Respect /pua:off — skip injection when always_on is false
 PUA_CONFIG="${HOME:-~}/.pua/config.json"
 if [ -f "$PUA_CONFIG" ]; then
-  ALWAYS_ON=$(python3 -c "import json; print(json.load(open('$PUA_CONFIG')).get('always_on', True))" 2>/dev/null || echo "True")
+  ALWAYS_ON=$(python3 -c "import os,json; print(json.load(open(os.path.expanduser('~/.pua/config.json'))).get('always_on', True))" 2>/dev/null || echo "True")
   if [ "$ALWAYS_ON" = "False" ]; then
     exit 0
   fi

--- a/hooks/frustration-trigger.sh
+++ b/hooks/frustration-trigger.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Respect /pua:off — skip injection when always_on is false
 PUA_CONFIG="${HOME:-~}/.pua/config.json"
 if [ -f "$PUA_CONFIG" ]; then
-  ALWAYS_ON=$(python3 -c "import json; print(json.load(open('$PUA_CONFIG')).get('always_on', True))" 2>/dev/null || echo "True")
+  ALWAYS_ON=$(python3 -c "import os,json; print(json.load(open(os.path.expanduser('~/.pua/config.json'))).get('always_on', True))" 2>/dev/null || echo "True")
   if [ "$ALWAYS_ON" = "False" ]; then
     exit 0
   fi


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## What's broken

`hooks/failure-detector.sh` (line 10) and `hooks/frustration-trigger.sh` (line 8) both check whether PUA is enabled with:

```bash
PUA_CONFIG="${HOME:-~}/.pua/config.json"
ALWAYS_ON=$(python3 -c "import json; print(json.load(open('$PUA_CONFIG')).get('always_on', True))" 2>/dev/null || echo "True")
```

`$PUA_CONFIG` is interpolated into the Python source string at the shell level. If a user's `$HOME` path contains a single quote (e.g. `/home/o'malley`) or other shell-special characters, the Python expression becomes a syntax error. Because the `2>/dev/null` swallows the error and `|| echo "True"` provides the fallback, the hook silently assumes `always_on=True` — meaning `/pua:off` has no effect for those users.

## Fix

Replace the interpolated path with `os.path.expanduser('~/.pua/config.json')` using a hardcoded tilde. This is the same pattern already used safely in `stop-feedback.sh` and `session-restore.sh`:

```bash
ALWAYS_ON=$(python3 -c "import os,json; print(json.load(open(os.path.expanduser('~/.pua/config.json'))).get('always_on', True))" 2>/dev/null || echo "True")
```

One-line change per file; zero behavioral change for users with standard home directories.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":null,"fingerprint":"sha256:c00926b0e8ff1dc152d35910f388f922848ced70e20ce1d59ba1ca8d7eafaf63"},{"rule_id":null,"fingerprint":"sha256:9367e017d8afd1d3e8e4b39072334ef2c63ff552cdb630ff8117bc5c131f4300"}]}
nlpm-metadata-end -->