### PR TITLE
fix(security): replace /tmp/pua-plugin-root TOCTOU race with CLAUDE_PLUGIN_ROOT

### DIFF
--- a/hooks/stop-feedback.sh
+++ b/hooks/stop-feedback.sh
@@ -50,14 +50,6 @@ echo "$count" > "$COUNTER"
 
 # Embed dynamic runtime values so Claude's bash context can use them
 printf '%s' "$TRANSCRIPT_PATH" > /tmp/pua-session-path
-if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]]; then
-  _PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT"
-else
-  _PLUGIN_ROOT=$(ls -td "${HOME:-~}/.claude/plugins/cache/pua-skills/pua/"*/ 2>/dev/null | head -1)
-  _PLUGIN_ROOT="${_PLUGIN_ROOT%/}"
-  : "${_PLUGIN_ROOT:=${HOME:-~}/.claude/plugins/pua}"
-fi
-printf '%s' "$_PLUGIN_ROOT" > /tmp/pua-plugin-root
 
 cat <<'FEEDBACK'
 IMPORTANT — BEFORE doing anything else, you MUST execute this feedback flow:
@@ -102,7 +94,7 @@ If user chose "很有用 — 上传评分 + 脱敏 session":
 curl -s -X POST https://pua-skill.pages.dev/api/feedback \
   -H "Content-Type: application/json" \
   -d "{\"rating\":\"很有用\",\"pua_count\":0,\"flavor\":\"阿里\",\"task_summary\":\"brief task description\"}"
-bash "$(cat /tmp/pua-plugin-root)/hooks/sanitize-session.sh" "$(cat /tmp/pua-session-path)"
+bash "${CLAUDE_PLUGIN_ROOT:-$(ls -td ~/.claude/plugins/cache/pua-skills/pua/*/ | head -1)}/hooks/sanitize-session.sh" "$(cat /tmp/pua-session-path)"
 python3 -c "
 import json, urllib.request
 data = open('/tmp/pua-sanitized-session.jsonl', encoding='utf-8').read()


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Issue (Medium)

`hooks/stop-feedback.sh` contains a TOCTOU (time-of-check/time-of-use) race condition in the plugin root path lookup.

**The vulnerable pattern:**
```bash
# Shell writes path to /tmp at hook start
printf '%s' "$_PLUGIN_ROOT" > /tmp/pua-plugin-root

# Claude later executes this instruction from the heredoc:
bash "$(cat /tmp/pua-plugin-root)/hooks/sanitize-session.sh" ...
```

On a shared or multi-user system, an attacker with write access to `/tmp/` can overwrite `/tmp/pua-plugin-root` between the write and the exec, redirecting Claude to run an arbitrary script. The window is small but real — Claude has to process the hook output and present a question before executing the bash block, giving an attacker several seconds.

## Fix

Replace the temp file with `${CLAUDE_PLUGIN_ROOT}`, the authoritative env var that `hooks.json` already uses:

```bash
bash "${CLAUDE_PLUGIN_ROOT:-$(ls -td ~/.claude/plugins/cache/pua-skills/pua/*/ | head -1)}/hooks/sanitize-session.sh" ...
```

This reads the plugin root directly from the process environment at exec time — no writable file involved, no race window. The `ls` fallback preserves behaviour in environments where `CLAUDE_PLUGIN_ROOT` is not set.

The dead code that computed `_PLUGIN_ROOT` and wrote it to the temp file is also removed.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":null,"fingerprint":"sha256:0b765350bd4519754210274645bbf2627b0726a9449a0ff6020aa03c73df0cfc"}]}
nlpm-metadata-end -->