### PR TITLE
fix(hooks): close unbalanced apostrophe in stop-feedback heredoc to fix Stop hook syntax error

### DIFF
--- a/hooks/stop-feedback.sh
+++ b/hooks/stop-feedback.sh
@@ -123,7 +123,7 @@ UPLOAD_RESPONSE=$(curl -sS --max-time 30 -X POST https://pua-skill.pages.dev/api
 echo "脱敏 session 已匿名上传：$UPLOAD_RESPONSE"
 ```
 
-Do NOT upload anything without user's explicit choice. Call AskUserQuestion NOW.
+Do NOT upload anything without explicit user consent. Call AskUserQuestion NOW.
 
 ## Step 3: Leaderboard auto-submit (if registered)
 ## Note: Leaderboard registration/view/quit logic lives in pua:pro skill, NOT here.


### PR DESCRIPTION
## Bug

`hooks/stop-feedback.sh` fails `bash -n` with:

```
hooks/stop-feedback.sh: line 150: unexpected EOF while looking for matching \`'\`
hooks/stop-feedback.sh: line 151: syntax error: unexpected end of file
```

This makes the Stop hook log a bash error every time a Claude Code session ends. Functionality isn't broken (the hook exits before reaching anything destructive), but it's noisy and breaks `bash -n` lint in CI.

## Root cause

The hook builds the prompt body with:

```bash
_feedback_text=$(cat <<'FEEDBACK'
...
Do NOT upload anything without user's explicit choice. Call AskUserQuestion NOW.
...
FEEDBACK
)
```

Although the heredoc delimiter is quoted (`<<'FEEDBACK'`, body not expanded), bash still tracks ASCII single quotes while parsing the surrounding `$(...)` command substitution. The lone apostrophe in `user's` (line 126) leaves `$(...)` looking unbalanced, so bash reports the EOF/quote error against the closing region near line 150.

Minimum reproducer:

```
$ x=$(cat <<'EOF'
this has 'one quote
EOF
)
bash: line 3: unexpected EOF while looking for matching \`'\`
```

The other ASCII `'` inside the heredoc (`os.path.expanduser('~/.pua/config.json')`, `'leaderboard'`, `'id'`, `''`, etc.) are already paired, so `user's` is the only unbalanced one.

## Fix

Rephrase the line to drop the apostrophe entirely. Semantics preserved.

```diff
-Do NOT upload anything without user's explicit choice. Call AskUserQuestion NOW.
+Do NOT upload anything without explicit user consent. Call AskUserQuestion NOW.
```

## Verification

Before:

```
$ bash -n hooks/stop-feedback.sh; echo $?
hooks/stop-feedback.sh: line 150: unexpected EOF while looking for matching \`'\`
hooks/stop-feedback.sh: line 151: syntax error: unexpected end of file
2
```

After:

```
$ bash -n hooks/stop-feedback.sh; echo $?
0
```

Existing eval scripts (`evals/test-issue-regressions.sh`, `test-upload-flow.sh`, `test-feedback-auth.sh`, `test-release-consistency.sh`) assert tokens like `X-PUA-Upload-Consent`, `/api/upload`, `--data-binary @`, `仅上传评分` — all still present after this change.

## Future-proofing (optional, out of scope)

The heredoc-as-prompt-template pattern is fragile against future text edits adding stray ASCII apostrophes (`it's`, `don't`, English possessives). Two options if maintainers want a more durable fix in a follow-up:

1. Externalize the prompt to `hooks/stop-feedback.prompt.md` and read it via `_feedback_text=$(<"$SCRIPT_DIR/stop-feedback.prompt.md")` — no surrounding `$(...)` tracking quotes.
2. Add `bash -n hooks/*.sh` to CI / evals so future stray apostrophes fail fast.