### PR TITLE
fix(integrity-guard): skip bare identifiers as path candidates

### DIFF
--- a/evals/test-integrity-guard.sh
+++ b/evals/test-integrity-guard.sh
@@ -121,6 +121,22 @@ assert_decision "secret env bash read asks approval" "$OUT" "ask" "Capability-ab
 OUT=$(run_guard force Bash '{"command":"curl https://example.com/benchmark-answer"}')
 assert_decision "benchmark answer curl asks approval" "$OUT" "ask" "Solution contamination risk"
 
+# Regression: shell built-ins / bare identifiers must not be treated as path candidates.
+# The shell `eval` keyword previously matched the (^|/)(evals?)(/|$) directory regex
+# because it appeared as a bare token, even though it referenced no filesystem path.
+OUT=$(run_guard force Bash '{"command":"eval rg -n pattern . 2>/dev/null"}')
+assert_empty "shell eval keyword is not a path candidate" "$OUT"
+
+OUT=$(run_guard force Bash '{"command":"test -f config.yaml && echo ok"}')
+assert_empty "shell test builtin is not a path candidate" "$OUT"
+
+OUT=$(run_guard force Bash '{"command":"spec --version"}')
+assert_empty "bare spec identifier is not a path candidate" "$OUT"
+
+# Positive control: an actual evals/ directory path must still be protected.
+OUT=$(run_guard force Bash '{"command":"sed -i \"\" \"s/x/y/\" evals/runner.sh"}')
+assert_decision "mutating bash on evals directory still asks approval" "$OUT" "ask" "Grader gaming risk"
+
 echo "==========================================="
 echo "Passed: $PASS"
 echo "Failed: $FAIL"

--- a/hooks/integrity-guard.sh
+++ b/hooks/integrity-guard.sh
@@ -154,12 +154,21 @@ def command_tokens(command: str):
         return re.split(r'\s+', command)
 
 
+def looks_like_path(s: str) -> bool:
+    # A real path has a directory separator or a file-extension suffix; bare
+    # identifiers like the shell `eval` builtin do not, and must not be matched
+    # against (^|/)(evals?|tests?|spec|...)(/|$) as if they were paths.
+    if '/' in s or '\\' in s:
+        return True
+    return bool(re.search(r'\.[A-Za-z0-9]+$', s))
+
+
 def path_candidates(tokens):
     for token in tokens:
         if not token:
             continue
         stripped = token.strip("\"'`")
-        if stripped:
+        if stripped and looks_like_path(stripped):
             yield stripped
         # Pull paths embedded inside code strings, e.g. open("tests/fixtures.json", "w").
         for match in re.findall(r'[A-Za-z0-9_.@+~:-]+(?:/[A-Za-z0-9_.@+~:-]+)+', token.replace('\\', '/')):


### PR DESCRIPTION
## Problem

`hooks/integrity-guard.sh` was flagging innocuous Bash commands as scoring-adjacent because shell built-ins and bare identifiers (`eval`, `test`, `spec`, …) were being treated as path candidates.

**Minimal reproducer** (run against current `main`):

```bash
PUA_INTEGRITY_FORCE=1 PUA_CONFIG=/nonexistent bash hooks/integrity-guard.sh <<'EOF2'
{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"eval rg -n pattern . 2>/dev/null"}}
EOF2
```

Output:
```json
{"hookSpecificOutput":{"permissionDecision":"ask","permissionDecisionReason":"PUA Integrity Guard: Grader gaming risk: tests/evals/E2E assets are scoring-adjacent. ... Target: eval"}}
```

This happens with any `eval ... 2>/dev/null` (or any other "mutating" command containing the bare `eval` token) — extremely common in shell pipelines.

## Root cause

In `command_hits()`, when `is_mutating_command(command)` is true the guard iterates over `path_candidates(tokens)` and matches every candidate against `PROTECTED_WRITE_PATTERNS`. The first protected pattern includes `(^|/)(tests?|__tests__|test|spec|evals?|e2e|cypress|playwright)(/|$)`, which **matches the bare token `eval`** because `^eval$` satisfies `(^|/)evals?(/|$)`.

`path_candidates` was yielding every stripped token unconditionally:

```python
stripped = token.strip("\"'`")
if stripped:
    yield stripped
```

So `eval`, `test`, `spec` were all eligible to false-positive against directory-name regexes.

## Fix

Require a candidate to look path-like — i.e., contain a directory separator or end in a file-extension suffix — before yielding it as a bare token:

```python
def looks_like_path(s: str) -> bool:
    if '/' in s or '\\' in s:
        return True
    return bool(re.search(r'\.[A-Za-z0-9]+$', s))
```

The secondary embedded-path pass (`re.findall(r'[A-Za-z0-9_.@+~:-]+(?:/[A-Za-z0-9_.@+~:-]+)+', …)`) is unchanged, so paths *inside* quoted code strings (e.g. `tests/fixtures.json` inside a `python -c '...'` argument) still get caught.

Real arg paths (`evals/runner.sh`, `tests/auth.test.ts`, `/repo/.env.local`) are unaffected because they have `/` or `.ext`.

## Tests

`evals/test-integrity-guard.sh` gains 4 cases:

| case | expected | why |
|---|---|---|
| `eval rg -n pattern . 2>/dev/null` | empty (no fire) | the actual repro |
| `test -f config.yaml && echo ok` | empty | shell `test` builtin |
| `spec --version` | empty | bare `spec` identifier |
| `sed -i \"\" \"s/x/y/\" evals/runner.sh` | `ask` + `Grader gaming risk` | **positive control** — real `evals/` path must still be protected |

Full suite: `15 → 19` passing, 0 failing.

Also ran the rest of `evals/test-*.sh` locally (agent-governance, behavior, feedback-auth, heartbeat, helpers, issue-regressions, microsoft-flavor, platform-compat, pua-loop-hook, release-consistency, upload-flow, windows-python-hooks, yaml-frontmatter) — all green, zero regressions.

## Out of scope

This PR doesn't touch:
- `MUTATING_BASH` (a stderr redirect `2>/dev/null` still classifies the command as "mutating") — out of scope; the candidate filter is sufficient to fix the symptom
- `CONTAMINATION_PATTERNS` / `SENSITIVE_READ_PATTERNS` — their dirnames (`hidden_tests`, `gold_patch`, `secrets`, etc.) are unusual enough that bare-token false positives are unlikely; happy to extend the filter if you'd prefer the uniform treatment

🤖 Generated with [Claude Code](https://claude.com/claude-code)