### PR TITLE
fix(hooks): use `read -r -d ''` so bash 3.2 does not choke on heredoc body in stop-feedback.sh

### DIFF
--- a/hooks/stop-feedback.sh
+++ b/hooks/stop-feedback.sh
@@ -69,7 +69,15 @@ fi
 get_flavor
 _ACTUAL_FLAVOR="${PUA_FLAVOR:-alibaba}"
 
-_feedback_text=$(cat <<'FEEDBACK'
+# Use `read -r -d ''` instead of $(cat <<'FEEDBACK' ... FEEDBACK) — on macOS's
+# bash 3.2 the $(...) parser tracks single-quote nesting *inside* heredoc
+# bodies when scanning for the closing `)`, even though the heredoc terminator
+# is single-quoted. Any odd count of `'` chars in the body (e.g. `user's`)
+# trips "unexpected EOF while looking for matching `''" and disables the
+# entire Stop hook. `read -r -d ''` has no $(...) wrapping, so the parser
+# treats the body as literal — robust against future copy editing.
+# Refs: github.com/tanweai/pua/issues/166
+IFS= read -r -d '' _feedback_text <<'FEEDBACK' || true
 IMPORTANT — BEFORE doing anything else, you MUST execute this feedback flow:
 
 ## Step 1: Ask for rating + upload consent (single question, two parts)
@@ -142,7 +150,6 @@ curl -s -X POST https://pua-skill.pages.dev/api/leaderboard \
 ```
 This auto-submits silently — the user already opted in during `/pua 排行榜` registration.
 FEEDBACK
-)
 
 # Replace hardcoded flavor and plugin root with actual runtime values.
 _feedback_text="${_feedback_text//__PUA_PLUGIN_ROOT__/${_PLUGIN_ROOT}}"


### PR DESCRIPTION
## Summary

Fixes [#166](https://github.com/tanweai/pua/issues/166) — Stop hook completely disabled on macOS bash 3.2 since v3.4.6.

## Root cause (corrected)

The reporter on #166 attributed the failure to the `printf` parameter expansion on line 150 (UTF-8 `阿里` pattern + nested `${_ACTUAL_FLAVOR}`). I tested that printf in isolation on bash 3.2 — it parses fine. The actual culprit is one step upstream:

```bash
_feedback_text=$(cat <<'FEEDBACK'
…
FEEDBACK
)
```

bash 3.2 has a parser bug where `$(...)` command substitution tracks single-quote nesting **inside the heredoc body** when scanning for the matching `)`, *even when the terminator is single-quoted*. If the body has an odd count of `'` chars, the scanner believes a quote is unterminated and emits the EOF error at the next statement (line 150 in v3.4.6).

Diffing v3.4.5 → v3.4.6:

```diff
- Do NOT upload anything without explicit user consent. Call AskUserQuestion NOW.
+ Do NOT upload anything without user's explicit choice. Call AskUserQuestion NOW.
```

That single apostrophe in `user's` flipped the body's `'` count from 14 (even) to 15 (odd). v3.4.5 happened to parse because the count was even, not because the structure was correct.

Minimal reproducer:

```bash
$ cat > /tmp/repro.sh <<'OUTER'
#!/bin/bash
x=$(cat <<'BODY'
user's choice
'a' 'b' 'c'
BODY
)
echo done
OUTER
$ /bin/bash -n /tmp/repro.sh
/tmp/repro.sh: line 4: unexpected EOF while looking for matching `''
/tmp/repro.sh: line 8: syntax error: unexpected end of file
```

Bump the body to an even count and it parses. Same shape as the v3.4.6 regression.

## Fix

Drop `$(cat <<'FEEDBACK' … FEEDBACK)` and assign via `IFS= read -r -d '' _feedback_text <<'FEEDBACK' … FEEDBACK`. No `$(...)`, so the parser never has to balance quotes inside the body — the heredoc body is treated as literal bytes.

```bash
IFS= read -r -d '' _feedback_text <<'FEEDBACK' || true
…
FEEDBACK
```

`read -d ''` reads until a NUL byte (never present in the body), then returns non-zero when EOF is hit — but the variable is still fully populated. The `|| true` swallows that exit status so a future `set -e` doesn't surprise anyone.

Runtime behavior is identical to the existing code. The structural change also means future copy edits like adding "user's" or "didn't" can't reintroduce the bug.

## Test plan

- [x] `bash -n hooks/stop-feedback.sh` clean on `/bin/bash` 3.2.57(1)-release (macOS Darwin 25, arm64).
- [x] Running the script against a minimal `Stop` payload exits 0 instead of erroring.
- [x] Spot-checked: `_feedback_text` length matches what the old `$(...)` version would have produced (line count + byte count identical).
- [ ] Suggested CI follow-up: add a macOS runner step that runs `/bin/bash -n hooks/*.sh` — would have caught the v3.4.5 → v3.4.6 regression at PR time. Happy to do that in a follow-up PR if you'd like.

## Out of scope

I did not retitle the prompt body, did not touch the other hooks, and did not change the user-visible text in any way. This PR is the smallest structural fix that makes the body parse on bash 3.2 and stays robust to future apostrophes.

Refs #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
