### PR TITLE
fix(hooks): make stop-feedback.sh parse on bash 3.2 (macOS default)

### DIFF
--- a/hooks/stop-feedback.sh
+++ b/hooks/stop-feedback.sh
@@ -69,7 +69,14 @@ fi
 get_flavor
 _ACTUAL_FLAVOR="${PUA_FLAVOR:-alibaba}"
 
-_feedback_text=$(cat <<'FEEDBACK'
+# Use `read -r -d ''` instead of `$(cat <<'FEEDBACK' ... FEEDBACK)` to avoid a
+# bash 3.2 parser bug (macOS default `/bin/bash`) where the `$(...)` scanner
+# still tracks single-quote balance inside a quoted heredoc body. An odd
+# number of apostrophes in the body (e.g. `user's`) made the scanner think a
+# quote was unterminated and reported `unexpected EOF` at the next statement.
+# `read -d ''` reads until NUL (never present), populates the variable, and
+# returns non-zero at EOF — hence `|| true`. See issue #166.
+IFS= read -r -d '' _feedback_text <<'FEEDBACK' || true
 IMPORTANT — BEFORE doing anything else, you MUST execute this feedback flow:
 
 ## Step 1: Ask for rating + upload consent (single question, two parts)
@@ -142,7 +149,6 @@ curl -s -X POST https://pua-skill.pages.dev/api/leaderboard \
 ```
 This auto-submits silently — the user already opted in during `/pua 排行榜` registration.
 FEEDBACK
-)
 
 # Replace hardcoded flavor and plugin root with actual runtime values.
 _feedback_text="${_feedback_text//__PUA_PLUGIN_ROOT__/${_PLUGIN_ROOT}}"


### PR DESCRIPTION
## 问题

`hooks/stop-feedback.sh` 在 macOS 自带 `/bin/bash`（3.2.57）上 `bash -n` 即报：

```
line 150: unexpected EOF while looking for matching `''
line 151: syntax error: unexpected end of file
```

后果：所有 macOS 用户（凡是没装 Homebrew bash 的）每次 Stop 事件都会看到这两行红色 hook 错误，且 stop-feedback 功能（评分询问、leaderboard 上报、PIP 反馈注入）整体失效——脚本根本走不到逻辑就崩了。

涉及 issue：#166（含 @ShunmeiCho 的精准诊断和方案）、#165（同 bug 的简短报告）。

## 根因

bash 3.2 的 `$(...)` 命令替换 scanner 有一个长期存在的 parser bug：**即使 heredoc 定界符是单引号化的（`<<'FEEDBACK'`），scanner 在寻找 `$(...)` 的闭合 `)` 时仍会跟踪 heredoc body 内的单引号配对**。若 body 内单引号数为奇数，scanner 误以为有未闭合引号，一直扫到文件末尾报 `unexpected EOF`。bash 4+ 已修，但 macOS 因 GPLv3 许可限制永久卡在 3.2。

v3.4.5 → v3.4.6 的回归：

```diff
- Do NOT upload anything without explicit user consent. Call AskUserQuestion NOW.
+ Do NOT upload anything without user's explicit choice. Call AskUserQuestion NOW.
```

那个 `user's` 把 heredoc body 的单引号计数从偶数变成奇数。3.4.5 在 bash 3.2 上能跑，3.4.6 不行；两个版本在 bash 4+ 上都能跑。

最小复现：

```bash
cat > /tmp/repro.sh <<'OUTER'
#!/bin/bash
x=$(cat <<'BODY'
user's choice
'a' 'b' 'c'
BODY
)
echo done
OUTER
/bin/bash -n /tmp/repro.sh
# /tmp/repro.sh: line 4: unexpected EOF while looking for matching `''
# /tmp/repro.sh: line 8: syntax error: unexpected end of file
```

body 里 7 个单引号 → 奇数 → 解析失败。加一个变 8 个就过。

## 修复

不去数单引号——那是没人能记住的负载不可见 invariant。直接绕开 `$(...)`，用 `read -r -d ''` 读到 NUL 退出（永远读不到 NUL → 读到 EOF 后变量已填充，返回非零 → `|| true` 吞掉）：

```diff
-_feedback_text=$(cat <<'FEEDBACK'
+IFS= read -r -d '' _feedback_text <<'FEEDBACK' || true
 ...heredoc body...
 FEEDBACK
-)
```

没有 `$(...)`，parser 不需要扫 heredoc body 找闭合 token，将来怎么改文案都不会再翻车。

完整 credit：方案来自 @ShunmeiCho 在 #166 的评论。

## 验证

```
$ /bin/bash --version | head -1
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)

$ /bin/bash -n hooks/stop-feedback.sh && echo OK
OK

$ echo '{"hook_event_name":"Stop","parent_session_id":"","transcript_path":"/tmp/test.jsonl","cwd":"/tmp"}' \
  | PUA_FLAVOR=bytedance /bin/bash hooks/stop-feedback.sh > /tmp/out.txt 2> /tmp/err.txt
$ echo "stdout=$(wc -l < /tmp/out.txt) stderr=$(wc -l < /tmp/err.txt)"
stdout=      72 stderr=       0
```

- `bash -n` 在 `/bin/bash` 3.2.57 和 Homebrew bash 5.x 上都干净
- 喂最小 `HOOK_INPUT`，exit 0，stdout 产出 72 行 feedback text，stderr 空
- 三个 placeholder 替换全部正确执行：
  - `__PUA_PLUGIN_ROOT__ → $_PLUGIN_ROOT`
  - `__PUA_SESSION_PATH__ → $TRANSCRIPT_PATH`
  - `"flavor":"阿里" → "flavor":"$_ACTUAL_FLAVOR"`（输出含 `flavor":"alibaba"` 等）

## 建议（后续，不在本 PR 范围）

为了避免类似 bash 3.2 解析回归再次进 main，可考虑在 CI 加一行 `bash -n hooks/*.sh`，在 GitHub Actions macos-latest runner（默认 `/bin/bash` 即 3.2.57）上跑，静态拦截这类问题。本 PR 不改 CI，留给 maintainer 决策。

Fixes #166. Closes #165.

---

PR co-authored with [Claude Code](https://claude.com/claude-code) (Opus 4.7) — 根因诊断和实施由 @sinnohzeng 与 Claude 协作完成；修复方案完全采纳 @ShunmeiCho 在 #166 的提议。
