### PR TITLE
fix(hooks): stop-feedback.sh crashes on macOS bash 3.2

### DIFF
--- a/hooks/stop-feedback.sh
+++ b/hooks/stop-feedback.sh
@@ -123,7 +123,7 @@ UPLOAD_RESPONSE=$(curl -sS --max-time 30 -X POST https://pua-skill.pages.dev/api
 echo "脱敏 session 已匿名上传：$UPLOAD_RESPONSE"
 ```
 
-Do NOT upload anything without user's explicit choice. Call AskUserQuestion NOW.
+Do NOT upload anything without the user explicit choice. Call AskUserQuestion NOW.
 
 ## Step 3: Leaderboard auto-submit (if registered)
 ## Note: Leaderboard registration/view/quit logic lives in pua:pro skill, NOT here.
@@ -147,4 +147,6 @@ FEEDBACK
 # Replace hardcoded flavor and plugin root with actual runtime values.
 _feedback_text="${_feedback_text//__PUA_PLUGIN_ROOT__/${_PLUGIN_ROOT}}"
 _feedback_text="${_feedback_text//__PUA_SESSION_PATH__/${TRANSCRIPT_PATH}}"
-printf '%s\n' "${_feedback_text//\\\"flavor\\\":\\\"阿里\\\"/\\\"flavor\\\":\\\"${_ACTUAL_FLAVOR}\\\"}"
+_pua_pat='\"flavor\":\"阿里\"'
+_pua_rep='\"flavor\":\"'"${_ACTUAL_FLAVOR}"'\"'
+printf '%s\n' "${_feedback_text//${_pua_pat}/${_pua_rep}}"


### PR DESCRIPTION
## Summary

The Stop hook `hooks/stop-feedback.sh` fails to parse on macOS, producing this error after every Claude Code session:

```
line 150: unexpected EOF while looking for matching `''
line 151: syntax error: unexpected end of file
```

## Root cause

macOS still ships **bash 3.2.57** as `/bin/bash` (the hook's shebang). The script uses a quoted heredoc `<<'FEEDBACK'` which on modern bash (4.x / 5.x) suppresses all parsing of the body. But bash 3.2 still scans heredoc bodies for unmatched single quotes — and the body contains `user's explicit choice` on line 126. The apostrophe is read as the start of a quoted string, the parser walks all the way to EOF looking for the close quote, and the script fails to load. The reported line number (150) is just where bash gave up; the real culprit is line 126.

Reproduce on any macOS:

```bash
$ bash --version | head -1
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
$ bash -n hooks/stop-feedback.sh
hooks/stop-feedback.sh: line 150: unexpected EOF while looking for matching `''
hooks/stop-feedback.sh: line 151: syntax error: unexpected end of file
```

## Fix

Two small changes, both in `hooks/stop-feedback.sh`:

1. **Line 126** — rewrite `user's explicit choice` → `the user explicit choice`. This is the actual fix for the EOF crash; it's the minimum needed for bash 3.2 to accept the heredoc.

2. **Line 150** — rewrite the inline `${var//\\\"…\\\"/\\\"…\\\"}` substitution to use two intermediate variables. Same behaviour, but the quoting is readable and won't regress in future edits. (Optional polish, but trivial.)

## Verification

```bash
$ bash -n hooks/stop-feedback.sh && echo OK
OK
$ echo '{"hook_event_name":"Stop","transcript_path":"/dev/null","parent_session_id":""}' | bash hooks/stop-feedback.sh
$ echo $?
0
```

Tested on bash 3.2.57 (system bash on macOS Darwin 25) where the script previously refused to parse.

## Impact

Every macOS user on the default `/bin/bash` sees the parse error in their Stop hook output on every session. The hook never gets a chance to ask for feedback. This PR restores that.