### PR TITLE
feat(integrity-guard): user-configurable path exclusion list

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -73,6 +73,24 @@ Codex 没有 Claude Code 的 `/pua:xxx` slash command 命名空间时，可以�
 这比强制 GitHub 登录更利于收集真实数据，同时避免“无同意、无脱敏、无限流”的裸奔上传。
 
 
+## Integrity Guard 怎么豁免特定路径？
+
+PUA Integrity Guard 默认对所有 `CLAUDE.md`、`memory/`、`.claude/settings.json` 等敏感路径都触发 advisory。**派生型 / 投影型目录**（symlink view、build cache、镜像、生成文档）里的同名文件通常只是上游治理规则的"指针"，本身不是 canonical 持久内存，对这些路径反复弹 advisory 是噪音。
+
+从这版起支持用户配置允许列表：
+
+- 配置文件路径：`~/.pua/integrity-guard-exclusions.json`（可被 `PUA_INTEGRITY_EXCLUSIONS` 环境变量覆盖）
+- 格式：
+  ```json
+  {"patterns": ["(^|/)derived-view-[^/]+/CLAUDE\\.md$", "(^|/)build-cache/[^/]+\\.md$"]}
+  ```
+  或 bare JSON 数组同样支持：`["(^|/)scratch/[^/]+\\.md$"]`
+- 语义：每条 pattern 是 Python `re` 模块的正则，自动 `re.I`，对 forward-slash 归一化后的路径做 `re.search`
+- 行为：命中任一 pattern 的路径在 `find_reason_for_path` 和 `command_hits` 两层都被短路，连 fallback 整命令正则匹配都不会触发
+- 回退：配置文件缺失或解析失败 → 空列表 → 行为与现版本完全一致（向后兼容）
+
+示例用例：维护多个 `~/projects/foo/derived-claude-md/`、`~/projects/bar/cache-view/CLAUDE.md` 这类符号链接视图时，加进 exclusion 即可保留对真正项目 CLAUDE.md 的提醒，同时不再被 view 文件的 advisory 打断节奏。
+
 ## Integrity Guard 为什么不再使用 `permissionDecision: "ask"`？
 
 从 v3.4.6 起，PUA Integrity Guard 将敏感但合法的操作降级为 advisory-only：只注入 `additionalContext`，不再输出 `permissionDecision: "ask"`。

--- a/evals/test-integrity-guard.sh
+++ b/evals/test-integrity-guard.sh
@@ -192,6 +192,59 @@ assert_decision "benchmark answer curl denied" "$OUT" "deny" "Solution contamina
 OUT=$(run_guard force Write '{"file_path":"/repo/tests/no-ask.test.ts","content":"skip"}')
 assert_no_permission_ask "permissionDecision ask is never emitted" "$OUT"
 
+# ---------- Configurable exclusions (PUA_INTEGRITY_EXCLUSIONS) ----------
+# A user-supplied config file can exempt explicit path patterns from all
+# integrity-guard advisories. Backward-compatible: with no config, behavior
+# is unchanged (covered by all the cases above which run with PUA_INTEGRITY_EXCLUSIONS unset).
+
+EXCLUSIONS_TMP=$(mktemp /tmp/pua-integrity-exclusions.XXXXXX.json)
+cat > "$EXCLUSIONS_TMP" <<'JSON'
+{"patterns": ["(^|/)derived-view-[^/]+/CLAUDE\\.md$", "(^|/)build-cache/[^/]+\\.md$"]}
+JSON
+
+run_guard_with_exclusions() {
+  local tool="$1"
+  local payload="$2"
+  PUA_INTEGRITY_EXCLUSIONS="$EXCLUSIONS_TMP" PUA_INTEGRITY_FORCE=1 PUA_CONFIG=/nonexistent/pua-config.json bash "$HOOK" <<<"$(json_input "$tool" "$payload")"
+}
+
+OUT=$(run_guard_with_exclusions Write '{"file_path":"/repo/derived-view-readonly/CLAUDE.md","content":"x"}')
+assert_empty "excluded CLAUDE.md write stays silent" "$OUT"
+
+OUT=$(run_guard_with_exclusions Write '{"file_path":"/repo/CLAUDE.md","content":"x"}')
+assert_advisory "non-excluded CLAUDE.md still advisory" "$OUT" "Persistent-memory risk"
+
+OUT=$(run_guard_with_exclusions Edit '{"file_path":"/repo/derived-view-admin/CLAUDE.md","old_string":"a","new_string":"b"}')
+assert_empty "excluded CLAUDE.md edit stays silent" "$OUT"
+
+OUT=$(run_guard_with_exclusions Bash '{"command":"touch /repo/derived-view-full/CLAUDE.md"}')
+assert_empty "excluded path bash mutating command stays silent" "$OUT"
+
+OUT=$(run_guard_with_exclusions Bash '{"command":"touch /repo/CLAUDE.md"}')
+assert_advisory "non-excluded path bash mutating command still advisory" "$OUT" "Persistent-memory risk"
+
+OUT=$(run_guard_with_exclusions Write '{"file_path":"/repo/build-cache/foo.md","content":"x"}')
+assert_empty "second exclusion pattern also applies" "$OUT"
+
+OUT=$(run_guard_with_exclusions Write '{"file_path":"/repo/memory/session.md","content":"x"}')
+assert_advisory "memory write outside exclusion list still advisory" "$OUT" "Persistent-memory risk"
+
+# Malformed config should be silently ignored (no exclusions applied, no crash).
+BAD_CFG=$(mktemp /tmp/pua-integrity-exclusions-bad.XXXXXX.json)
+printf 'not valid json {' > "$BAD_CFG"
+OUT=$(PUA_INTEGRITY_EXCLUSIONS="$BAD_CFG" PUA_INTEGRITY_FORCE=1 PUA_CONFIG=/nonexistent/pua-config.json bash "$HOOK" <<<"$(json_input Write '{"file_path":"/repo/CLAUDE.md","content":"x"}')")
+assert_advisory "malformed exclusions config falls back to default behavior" "$OUT" "Persistent-memory risk"
+rm -f "$BAD_CFG"
+
+# Bare JSON array format also supported.
+ARRAY_CFG=$(mktemp /tmp/pua-integrity-exclusions-arr.XXXXXX.json)
+printf '["(^|/)scratch/[^/]+\\\\.md$"]' > "$ARRAY_CFG"
+OUT=$(PUA_INTEGRITY_EXCLUSIONS="$ARRAY_CFG" PUA_INTEGRITY_FORCE=1 PUA_CONFIG=/nonexistent/pua-config.json bash "$HOOK" <<<"$(json_input Write '{"file_path":"/repo/scratch/note.md","content":"x"}')")
+assert_empty "bare-array config format works" "$OUT"
+rm -f "$ARRAY_CFG"
+
+rm -f "$EXCLUSIONS_TMP"
+
 echo "==========================================="
 echo "Passed: $PASS"
 echo "Failed: $FAIL"

--- a/hooks/integrity-guard.sh
+++ b/hooks/integrity-guard.sh
@@ -96,6 +96,40 @@ SENSITIVE_READ_PATTERNS = [
     (re.compile(r'(^|/)\.env(\.|$)|(^|/)(secrets?|credentials?)(\.|/|$)|(^|/)(id_rsa|id_ed25519|private[-_]?key)(\.|$)', re.I), 'Capability-abuse risk: secrets and credentials require human gate.'),
 ]
 
+
+def load_excluded_patterns():
+    """User-configurable allowlist of path patterns exempt from all integrity-guard advisories.
+
+    Source: $PUA_INTEGRITY_EXCLUSIONS env var, else ~/.pua/integrity-guard-exclusions.json.
+    Format: {"patterns": ["regex1", "regex2", ...]} or a bare JSON array of strings.
+    Patterns compile with re.I and match via re.search against forward-slash-normalized paths.
+    Missing/malformed config → empty list (no behavioral change vs current default).
+    """
+    cfg = os.environ.get('PUA_INTEGRITY_EXCLUSIONS') or str(Path.home() / '.pua' / 'integrity-guard-exclusions.json')
+    try:
+        data = json.loads(Path(cfg).expanduser().read_text(encoding='utf-8'))
+    except Exception:
+        return []
+    if isinstance(data, dict):
+        raw = data.get('patterns') or []
+    elif isinstance(data, list):
+        raw = data
+    else:
+        raw = []
+    compiled = []
+    for p in raw:
+        if not isinstance(p, str):
+            continue
+        try:
+            compiled.append(re.compile(p, re.I))
+        except re.error:
+            continue
+    return compiled
+
+
+EXCLUDED_PATH_PATTERNS = load_excluded_patterns()
+
+
 MUTATING_BASH = re.compile(
     r'(^|[;&|()\s])(rm|mv|cp|chmod|chown|truncate|tee|touch|mkdir|rmdir|git\s+(reset|clean|checkout|restore)|sed\s+(-i|--in-place)|perl\s+-p?i|python3?\s+.*open\(|node\s+.*writeFile|npm\s+version)\b|>>|>[^&]',
     re.I | re.S,
@@ -118,6 +152,13 @@ def norm_path(p: str) -> str:
     return p.replace('\\', '/')
 
 
+def is_excluded_path(path: str) -> bool:
+    if not EXCLUDED_PATH_PATTERNS:
+        return False
+    n = norm_path(path)
+    return any(rx.search(n) for rx in EXCLUDED_PATH_PATTERNS)
+
+
 def collect_paths(value):
     paths = []
     if isinstance(value, dict):
@@ -134,6 +175,8 @@ def collect_paths(value):
 
 def find_reason_for_path(path: str, include_write: bool):
     n = norm_path(path)
+    if is_excluded_path(n):
+        return None
     for rx, reason in CONTAMINATION_PATTERNS:
         if rx.search(n):
             return 'deny', reason, n
@@ -202,14 +245,22 @@ def command_hits(command: str):
 
     # Protected scoring assets need a human gate only when the command mutates them.
     if is_mutating_command(command):
-        for candidate in candidates:
+        # Bucket candidates so we can ignore excluded paths at every layer.
+        excluded_hits = [c for c in candidates if is_excluded_path(c)]
+        non_excluded_candidates = [c for c in candidates if not is_excluded_path(c)]
+        for candidate in non_excluded_candidates:
             for rx, reason in PROTECTED_WRITE_PATTERNS:
                 if rx.search(norm_path(candidate)):
                     return 'advisory', reason, candidate
-        for rx, reason in PROTECTED_WRITE_PATTERNS:
-            m = rx.search(normalized)
-            if m:
-                return 'advisory', reason, m.group(0)
+        # Fallback whole-command regex: skip if the command involved any
+        # excluded path — the regex would just rediscover it via substring
+        # match (e.g. `touch /repo/excluded-view/CLAUDE.md` re-matching
+        # `(^|/)CLAUDE\.md$` against the literal command string).
+        if not excluded_hits:
+            for rx, reason in PROTECTED_WRITE_PATTERNS:
+                m = rx.search(normalized)
+                if m:
+                    return 'advisory', reason, m.group(0)
     return None
 
 hit = None


### PR DESCRIPTION
## Problem

`hooks/integrity-guard.sh` fires an advisory on any `Write` / `Edit` / `Bash` mutating command that touches a `CLAUDE.md`, `memory/` path, or `.claude/settings.json` — anywhere on the filesystem. This is correct for canonical project governance files, but is **noisy for derived / projected directories** (symlink views, build caches, mirrors, generated docs) where the same-named files are governance *pointers* to upstream, not canonical persistent memory themselves.

Concrete reproducer: a user maintains `~/projects/myrepo/views/admin/CLAUDE.md` that is a guardrail pointer to `~/projects/myrepo/04-memory/`. Every `touch` / `Write` / `Edit` on the view's `CLAUDE.md` fires advisory, even though the write is pre-authorized and the file isn't itself canonical memory.

```bash
PUA_INTEGRITY_FORCE=1 PUA_CONFIG=/nonexistent bash hooks/integrity-guard.sh <<'EOF2'
{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"touch /repo/views/admin/CLAUDE.md"}}
EOF2
```

Output:
```json
{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"PUA Integrity Guard (advisory): Persistent-memory risk: ... Target: /CLAUDE.md"}}
```

There is currently no way to suppress this without disabling Integrity Guard wholesale (`always_on: false`) or editing the cached script directly (lost on next plugin upgrade).

## Fix

Read `~/.pua/integrity-guard-exclusions.json` (overridable via `\$PUA_INTEGRITY_EXCLUSIONS`). Format:

\`\`\`json
{\"patterns\": [\"(^|/)derived-view-[^/]+/CLAUDE\\\\.md\$\"]}
\`\`\`

Bare JSON array also supported.

- Patterns compile with \`re.I\` and match via \`re.search\` against forward-slash-normalized paths
- Missing / malformed config → empty list → behavior identical to current default (**fully backward-compatible**)

Two integration points:

1. \`find_reason_for_path()\` short-circuits via \`is_excluded_path(n)\`
2. \`command_hits()\` buckets candidates so the fallback whole-command regex is suppressed when any candidate was excluded. Without this bucket logic, a command like \`touch /excluded/CLAUDE.md\` would still leak: bare tokens like \`touch\` stay in \`non_excluded_candidates\`, the per-candidate loop finds no match, and the fallback regex substring-matches \`/CLAUDE.md\` against the literal command, re-firing the advisory. The fix gates the fallback on \`if not excluded_hits\`.

## Tests

Adds 9 new cases to \`evals/test-integrity-guard.sh\` covering:

- Excluded paths stay silent for Write / Edit / Bash mutating commands
- Non-excluded paths still trigger advisories (no regression)
- Second exclusion pattern matches independently
- Memory paths outside the exclusion list still trigger (boundary)
- Malformed config silently falls back to default behavior
- Bare JSON array config format works

Suite goes 19/19 → 28/28 passing. No existing test regression.

\`\`\`
\$ bash evals/test-integrity-guard.sh
...
===========================================
Passed: 28
Failed: 0
Total:  28
===========================================
\`\`\`

## Docs

Adds an FAQ section (\`docs/FAQ.md\`) explaining the config file format, semantics, and typical derived-artifact use case.

## Why not just edit \`PROTECTED_WRITE_PATTERNS\` to be narrower?

The existing patterns are intentionally conservative — they're correct for the typical agent workspace. The drift cases (derived views, build caches) are user-specific and should be opt-in per-environment, not hardcoded. A config-driven allowlist preserves the safe default while giving advanced users an escape hatch.

## Co-author note

Drafted with \`Claude Opus 4.7 (1M context)\` while building a paired skill pack for derived-artifact CLAUDE.md governance ([Fearvox/derived-claude-md](https://github.com/Fearvox/derived-claude-md)) — the use case that motivated this PR.