### PR TITLE
fix(hooks): replace $(cat) with IFS= read for WSL socket stdin compatibility

### DIFF
--- a/hooks/failure-detector.sh
+++ b/hooks/failure-detector.sh
@@ -23,8 +23,10 @@ COUNTER_FILE="${HOME:-~}/.pua/.failure_count"
 SESSION_FILE="${HOME:-~}/.pua/.failure_session"
 mkdir -p "${HOME:-~}/.pua"
 
-# Read hook input
-HOOK_INPUT=$(cat)
+# Read hook input — bash builtin read (fd0 is a socket in WSL, /dev/stdin not available)
+HOOK_INPUT=""
+{ IFS= read -r HOOK_INPUT; } || true
+HOOK_INPUT="${HOOK_INPUT%$'\n'}"
 
 # Only process Bash tool results
 TOOL_NAME=$(echo "$HOOK_INPUT" | "${PUA_PY:-python3}" -c "import sys,json; print(json.load(sys.stdin).get('tool_name',''))" 2>/dev/null || echo "")

--- a/hooks/frustration-trigger.sh
+++ b/hooks/frustration-trigger.sh
@@ -18,7 +18,9 @@ if [ "${PUA_FORCE_ON:-0}" != "1" ]; then
   fi
 fi
 
-HOOK_INPUT=$(cat || true)
+HOOK_INPUT=""
+{ IFS= read -r HOOK_INPUT; } || true
+HOOK_INPUT="${HOOK_INPUT%$'\n'}"
 USER_PROMPT="$HOOK_INPUT"
 PUA_PY="$(pua_python_cmd 2>/dev/null || true)"
 if [ -n "$PUA_PY" ] && [ -n "$HOOK_INPUT" ]; then


### PR DESCRIPTION
## Problem
In WSL, `/dev/stdin` is a socket (not a device node), causing `$(cat)` to fail with "No such device or address" when `PostToolUse`/`UserPromptSubmit` hooks try to read hook input JSON.

## Fix
Replace `HOOK_INPUT=$(cat)` with bash builtin `IFS= read -r HOOK_INPUT` which reads directly from fd0 and works with socket file descriptors.

## Affected files
- `hooks/failure-detector.sh` line 27
- `hooks/frustration-trigger.sh` line 21

## Verification
- Manual simulation with pipe stdin: counter increments correctly, L1-L4 pressure output verified
- Three-way file sync confirmed (marketplaces/ cache/ APPS/pua/) all MD5 match