### PR TITLE
Add Codex plugin hooks support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     "plugins": [
         {
             "name": "pua",
-            "description": "PUA productivity coaching — modular skills, 15 workplace/corporate flavors including Ding Inside/Outside, completion-quality checks, retry/change-approach reminders, and feedback tools.",
+            "description": "v3.5.0: PUA productivity coaching — modular skills, 15 workplace/corporate flavors including Ding Inside/Outside, completion-quality checks, retry/change-approach reminders, and feedback tools.",
             "version": "3.5.0",
             "source": "./",
             "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,51 @@
+{
+  "name": "pua",
+  "version": "3.5.0",
+  "description": "Opt-in productivity coaching for Codex. Adds PUA skills, command aliases, and lifecycle hooks for evidence-first delivery, failure recovery, methodology switching, PUA Loop, and agent lifecycle accounting.",
+  "author": {
+    "name": "探微安全实验室",
+    "url": "https://github.com/tanweai"
+  },
+  "homepage": "https://openpua.ai",
+  "repository": "https://github.com/tanweai/pua",
+  "license": "MIT",
+  "keywords": [
+    "pua",
+    "codex",
+    "hooks",
+    "motivation",
+    "productivity",
+    "try-harder",
+    "retry",
+    "change-approach",
+    "frustration",
+    "quality-check",
+    "completion-checks",
+    "verify-before-done",
+    "evidence-first",
+    "agent-team",
+    "pua-loop",
+    "offline",
+    "feedback",
+    "jsonl"
+  ],
+  "skills": "./codex/",
+  "hooks": "./hooks/codex-hooks.json",
+  "interface": {
+    "displayName": "PUA",
+    "shortDescription": "Make Codex try harder with hooks",
+    "longDescription": "PUA for Codex bundles skills and lifecycle hooks for always-on coaching, frustration triggers, failure escalation, PreCompact checkpoints, PUA Loop continuation, and agent lifecycle accounting.",
+    "developerName": "TanWei Security Lab",
+    "category": "Productivity",
+    "capabilities": ["Skills", "Lifecycle hooks"],
+    "websiteURL": "https://openpua.ai",
+    "defaultPrompt": [
+      "Use $pua for this task.",
+      "Turn on PUA always-on mode.",
+      "Run this in PUA Loop until verified."
+    ],
+    "brandColor": "#f97316",
+    "composerIcon": "./assets/hero.jpeg",
+    "logo": "./assets/hero.jpeg"
+  }
+}

--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -1,125 +1,153 @@
-# Installing PUA Skill for Codex
+# Installing PUA for Codex
 
-Force AI to exhaust every possible solution before giving up. Installs via native skill discovery (`~/.codex/skills/`).
+Force Codex to exhaust alternatives before giving up. Full Codex support uses the native plugin manifest plus lifecycle hooks.
 
 ## Prerequisites
 
 - Git
+- Codex with hooks enabled
+- `jq`, `python3`, and `bash` available for hook scripts
 
-## Installation
+## Recommended Install
 
 ### macOS / Linux
 
 ```bash
 # 1. Clone the repo
-git clone https://github.com/tanweai/pua.git ~/.codex/pua
+git clone https://github.com/tanweai/pua.git ~/.codex/plugins/src/pua
 
-# 2. Create skill symlink (enables auto-discovery)
-mkdir -p ~/.codex/skills
-ln -s ~/.codex/pua/codex/pua ~/.codex/skills/pua
+# 2. Create a local Codex marketplace for PUA
+mkdir -p ~/.codex/.tmp/marketplaces/pua-local/.agents/plugins
+mkdir -p ~/.codex/.tmp/marketplaces/pua-local/plugins
+ln -sfn ~/.codex/plugins/src/pua ~/.codex/.tmp/marketplaces/pua-local/plugins/pua
 
-# 3. Install /prompts:pua trigger
-mkdir -p ~/.codex/prompts
-ln -s ~/.codex/pua/commands/pua.md ~/.codex/prompts/pua.md
+python3 - <<'PY'
+import json, os, pathlib
+root = pathlib.Path.home() / ".codex/.tmp/marketplaces/pua-local"
+path = root / ".agents/plugins/marketplace.json"
+data = {
+    "name": "pua-local",
+    "interface": {"displayName": "PUA Local"},
+    "plugins": [{
+        "name": "pua",
+        "source": {"source": "local", "path": "./plugins/pua"},
+        "policy": {"installation": "AVAILABLE", "authentication": "ON_INSTALL"},
+        "category": "Productivity",
+    }],
+}
+path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n")
+PY
 
-# 4. Restart Codex
+# 3. Register and install
+codex plugin marketplace add ~/.codex/.tmp/marketplaces/pua-local
+codex plugin add pua@pua-local
 ```
+
+Restart Codex, run `/hooks`, then trust the `pua@pua-local` hooks.
+
+Do not clone the plugin to `~/.codex/pua`. That old path can be discovered as an extra skill source and duplicate `$pua-*` entries in the skill picker.
 
 ### Windows (PowerShell)
 
 ```powershell
-# 1. Clone the repo
-git clone https://github.com/tanweai/pua.git "$env:USERPROFILE\.codex\pua"
-
-# 2. Create skill junction (enables auto-discovery)
-New-Item -ItemType Directory -Force "$env:USERPROFILE\.codex\skills"
-cmd /c mklink /J "$env:USERPROFILE\.codex\skills\pua" "$env:USERPROFILE\.codex\pua\codex\pua"
-
-# 3. Install /prompts:pua trigger
-# Use a hard link here because file symlinks often require extra Windows privileges.
-New-Item -ItemType Directory -Force "$env:USERPROFILE\.codex\prompts"
-cmd /c mklink /H "$env:USERPROFILE\.codex\prompts\pua.md" "$env:USERPROFILE\.codex\pua\commands\pua.md"
-
-# 4. Restart Codex
+git clone https://github.com/tanweai/pua.git "$env:USERPROFILE\.codex\plugins\src\pua"
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.codex\.tmp\marketplaces\pua-local\.agents\plugins"
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.codex\.tmp\marketplaces\pua-local\plugins"
+cmd /c mklink /J "$env:USERPROFILE\.codex\.tmp\marketplaces\pua-local\plugins\pua" "$env:USERPROFILE\.codex\plugins\src\pua"
 ```
+
+Then add the same marketplace entry under `%USERPROFILE%\.codex\.tmp\marketplaces\pua-local\.agents\plugins\marketplace.json`, run `codex plugin marketplace add`, run `codex plugin add pua@pua-local`, restart Codex, and trust hooks with `/hooks`.
+
+## Hook Loading Model
+
+Codex hooks are plugin-level lifecycle hooks. After `pua@pua-local` is installed and trusted, the same hook set runs for every session/event; selecting `$pua-p7`, `$pua-kpi`, or another PUA skill does not install a separate hook set.
+
+Skills are menu entries and turn-level instructions. Hooks are loaded before the first chat turn in a new session and then run on lifecycle events such as `SessionStart`, `UserPromptSubmit`, `PostToolUse`, `PreCompact`, `Stop`, and subagent start/stop.
+
+## What Full Codex Support Enables
+
+| Feature | Codex entry |
+|---|---|
+| Core PUA | `$pua` or `/pua:pua` |
+| Sub-modes | `$pua-p7`, `$pua-p9`, `$pua-p10`, `$pua-pro`, `$pua-yes`, `$pua-mama`, `$pua-shot` |
+| PUA Loop | `$pua-loop` or `/pua:pua-loop ...` |
+| Always-on | `$pua-on` or `/pua:on` |
+| Offline mode | `$pua-offline` or `/pua:offline` |
+| Survey/flavor/KPI | `$pua-survey`, `$pua-flavor`, `$pua-kpi` |
+| Agent lifecycle | `$pua-team-status`, `$pua-reap-orphans`, `$pua-teardown-all` |
+| Legacy prompt | `/prompts:pua` |
+
+Codex hooks provide:
+
+- `SessionStart`: always-on context and builder-journal recovery
+- `UserPromptSubmit`: frustration trigger and `/pua:*` command router
+- `PostToolUse:Bash`: failure escalation and methodology switch reminders
+- `PreCompact`: `~/.pua/builder-journal.md` checkpoint
+- `Stop`: PUA Loop continuation and silent optional-feedback bookkeeping
+- `SubagentStart/SubagentStop`: active-agent accounting
+- `PreToolUse`: integrity guard
+
+## Skill-only Fallback
+
+Use this only when you cannot install plugins or trust hooks:
+
+```bash
+mkdir -p ~/.codex/skills/pua
+curl -o ~/.codex/skills/pua/SKILL.md \
+  https://raw.githubusercontent.com/tanweai/pua/main/codex/pua/SKILL.md
+
+mkdir -p ~/.codex/prompts
+curl -o ~/.codex/prompts/pua.md \
+  https://raw.githubusercontent.com/tanweai/pua/main/commands/pua.md
+```
+
+Fallback supports `$pua` and `/prompts:pua`, but not deterministic lifecycle hooks. Do not combine the fallback with the plugin install unless you want duplicate skill picker entries.
 
 ## Verify
 
-Type `$pua` in a Codex conversation. If the skill is loaded, you'll see it activate.
+1. Restart Codex.
+2. Run `/plugins` and confirm PUA is installed.
+3. Run `/hooks` and trust PUA hooks.
+4. Start a new thread and type `/pua:on`.
+5. Start another new thread; PUA SessionStart context should be active.
 
-Or check directly:
-```bash
-# macOS / Linux
-ls ~/.codex/skills/pua/SKILL.md
-
-# Windows PowerShell
-Test-Path "$env:USERPROFILE\.codex\skills\pua\SKILL.md"
-```
-
-## Trigger Methods
-
-| Method | Command | Requires |
-|--------|---------|----------|
-| Auto trigger | No action needed, matches by description | SKILL.md |
-| Direct call | Type `$pua` in conversation | SKILL.md |
-| Manual prompt | Type `/prompts:pua` in conversation | SKILL.md + prompts/pua.md |
-
-## Language Variants
-
-| Language | Skill path |
-|----------|------------|
-| 🇨🇳 Chinese (default) | `codex/pua/SKILL.md` |
-| 🇺🇸 English (PIP) | `codex/pua-en/SKILL.md` |
-| 🇯🇵 Japanese | `codex/pua-ja/SKILL.md` |
-
-To install a different language variant, replace `pua` with `pua-en` or `pua-ja` in the symlink/junction step:
+Static file checks:
 
 ```bash
-# Example: English variant (macOS/Linux)
-ln -s ~/.codex/pua/codex/pua-en ~/.codex/skills/pua-en
+codex plugin list | grep 'pua@pua-local'
+find ~/.codex/plugins/cache/pua-local/pua -path '*/.codex-plugin/plugin.json' -print -quit
+find ~/.codex/plugins/cache/pua-local/pua -path '*/hooks/codex-hooks.json' -print -quit
 ```
 
 ## Update
 
 ```bash
-cd ~/.codex/pua
+cd ~/.codex/plugins/src/pua
 git pull
+codex plugin add pua@pua-local
 ```
 
-The symlink, junction, or hard link automatically picks up the latest version — no reinstall needed.
+Restart Codex and review `/hooks` again because changed hook definitions need fresh trust.
 
 ## Uninstall
 
-### macOS / Linux
+Remove the plugin from Codex, then remove the local checkout and marketplace entry:
 
 ```bash
-rm ~/.codex/skills/pua
-rm ~/.codex/prompts/pua.md
+codex plugin remove pua@pua-local
+codex plugin marketplace remove pua-local
+rm -rf ~/.codex/.tmp/marketplaces/pua-local
+rm -rf ~/.codex/plugins/src/pua
+```
+
+If you previously installed the deprecated skill source, remove it after checking for local changes:
+
+```bash
 rm -rf ~/.codex/pua
 ```
 
-### Windows (PowerShell)
+Optional local state cleanup:
 
-```powershell
-Remove-Item "$env:USERPROFILE\.codex\skills\pua"
-Remove-Item "$env:USERPROFILE\.codex\prompts\pua.md"
-Remove-Item -Recurse "$env:USERPROFILE\.codex\pua"
+```bash
+rm -rf ~/.pua
 ```
-
-
-## Claude Code subcommand aliases
-
-Codex can use `$pua-xxx` aliases for Claude Code `/pua:xxx` commands:
-
-| Claude Code | Codex CLI |
-|---|---|
-| `/pua:on` | `$pua-on` |
-| `/pua:off` | `$pua-off` |
-| `/pua:offline` | `$pua-offline` |
-| `/pua:p7` | `$pua-p7` |
-| `/pua:p9` | `$pua-p9` |
-| `/pua:p10` | `$pua-p10` |
-| `/pua:pro` | `$pua-pro` |
-| `/pua:pua-loop` | `$pua-loop` |
-
-Install by copying the `codex/pua-*` directories into your Codex skills directory next to `codex/pua`.

--- a/README.md
+++ b/README.md
@@ -305,16 +305,18 @@ Adds a bare `/pua` alias on top of the plugin. Sub-commands route through the in
 
 ### OpenAI Codex CLI
 
-Codex CLI uses the same Agent Skills open standard (SKILL.md). The Codex version uses a condensed description to fit Codex's length limits:
+Codex uses the same Agent Skills open standard (SKILL.md) and now ships a native Codex plugin manifest with lifecycle hooks. Use the plugin path when you want the full v3 behavior: always-on SessionStart injection, frustration triggers, Bash failure escalation, PreCompact checkpoints, PUA Loop continuation, silent optional-feedback bookkeeping, and subagent lifecycle accounting.
 
-**Recommended: One-command install (git clone + symlink, supports `git pull` updates)**
+**Recommended: plugin install from source (supports `git pull` updates)**
 
 Ask Codex to run:
 ```
 Fetch and follow instructions from https://raw.githubusercontent.com/tanweai/pua/main/.codex/INSTALL.md
 ```
 
-**Manual install:**
+The recommended install uses a local Codex marketplace (`pua@pua-local`) and a checkout under `~/.codex/plugins/src/pua`. Do not install the plugin checkout at `~/.codex/pua`; that deprecated path can be discovered as an extra skill source and duplicate `$pua-*` entries.
+
+**Manual skill-only fallback:**
 
 ```bash
 mkdir -p ~/.codex/skills/pua
@@ -330,9 +332,12 @@ curl -o ~/.codex/prompts/pua.md \
 
 | Method | Command | Requires |
 |--------|---------|----------|
-| Auto trigger | No action needed, matches by description | SKILL.md |
-| Direct call | Type `$pua` in conversation | SKILL.md |
-| Manual prompt | Type `/prompts:pua` in conversation | SKILL.md + prompts/pua.md |
+| Hook trigger | No action needed | Codex plugin + trusted hooks |
+| Direct call | Type `$pua` / `$pua-p7` / `$pua-loop` | Codex skills |
+| Text command | Type `/pua:on`, `/pua p9`, `/pua loop ...` | Codex plugin hooks |
+| Manual prompt | Type `/prompts:pua` | prompts fallback |
+
+Codex hooks are plugin-level lifecycle hooks. After `pua@pua-local` is installed and trusted in `/hooks`, the same hook set runs before the first turn of new sessions and on later lifecycle events. Selecting `$pua-p7`, `$pua-kpi`, or another PUA skill only changes the current turn's instructions; it does not install a separate hook set.
 
 Project-level install (current project only):
 
@@ -594,7 +599,7 @@ Spawn pua-enforcer as an independent watchdog in your Agent Team.
 | Platform | Auto-trigger | Manual trigger |
 |----------|-------------|----------------|
 | **Claude Code** | Yes (skill description matching) | See commands below |
-| **Codex CLI** | Yes (skill description matching) | `$pua` or `/prompts:pua` |
+| **Codex CLI** | Yes (skill description matching + hooks) | `$pua`, `$pua-*`, `/pua:*`, or `/prompts:pua` |
 | **Cursor** | Yes (`.mdc` rule, Agent Discretion) | — (auto only) |
 | **Kiro** | Yes (steering file or skill) | — (auto only) |
 | **CodeBuddy** | Yes (skill description matching) | Plugin commands (same as Claude Code) |
@@ -603,9 +608,9 @@ Spawn pua-enforcer as an independent watchdog in your Agent Team.
 | **OpenCode** | Yes (skill description matching) | — |
 | **VSCode Copilot** | Yes (instructions file) | `/pua` in Copilot Chat |
 
-> **Note:** Sub-modes (p7/p9/p10/pro/yes/pua-loop) are **Claude Code only** — other platforms install the core skill only.
+> **Note:** Full v3 hooks and sub-modes are available on Claude Code and Codex. Other platforms install the core skill unless their adapter says otherwise.
 
-### Architecture (Claude Code)
+### Architecture (Claude Code + Codex)
 
 ```
 /pua:pua        → Core engine — red lines + flavor + pressure + methodology router (v3)
@@ -620,18 +625,18 @@ Spawn pua-enforcer as an independent watchdog in your Agent Team.
 /pua:pua-en     → English PIP Edition
 /pua:pua-ja     → Japanese Edition
 
-Hooks (v3, Claude Code only):
+Hooks (v3, Claude Code + Codex):
   SessionStart  → additionalContext injection (flavor + methodology + router)
   PostToolUse   → Bash failure detection → L1-L4 pressure + methodology switch
   UserPromptSubmit → Script-level frustration filtering → PUA context
   PreCompact    → State preservation (pressure level + failure count)
-  Stop          → Feedback collection + PUA Loop continuation
+  Stop          → PUA Loop continuation + silent optional-feedback bookkeeping
   SubagentStop  → Agent lifecycle accounting (v3.2) — writes teardown.jsonl, removes from active-agents.json
 ```
 
-### Commands (Claude Code)
+### Commands (Claude Code + Codex)
 
-> **Note:** Sub-modes (p7/p9/p10/pro/yes/pua-loop) are Claude Code only.
+> **Note:** Codex exposes these as `$pua-*` skills and also accepts `/pua:*` text commands through the Codex UserPromptSubmit hook.
 >
 > Each command has two equivalent forms: standalone (`/pua:on`) or via the main command (`/pua:pua on`). Both work identically.
 
@@ -689,7 +694,7 @@ Based on research into high-agency individuals:
 
 > High-Agency features are built into the current pua skill. No separate install needed.
 
-## Methodology Router: PUA v3 (Claude Code)
+## Methodology Router: PUA v3 (Claude Code + Codex Hooks)
 
 **v3 = v2 + intelligent methodology routing + code-level behavioral detection**
 
@@ -720,7 +725,7 @@ Task arrives → Analyze type → Auto-select best methodology
               Not searching → ⚫ Baidu → 🔶 Amazon → 🟡 ByteDance
 ```
 
-### v3 Hook System (Claude Code only)
+### v3 Hook System (Claude Code + Codex Hooks)
 
 | Hook | Trigger | What It Does |
 |------|---------|-------------|
@@ -738,7 +743,7 @@ Task arrives → Analyze type → Auto-select best methodology
 | Failure response | Escalate pressure within same methodology | **Switch to different methodology** based on failure pattern |
 | System injection | Plain text output (advisory) | **`additionalContext` JSON** (system-level, like Superpowers) |
 
-> v3 hook features require Claude Code. Other platforms use the core skill without hooks.
+> v3 hook features require Claude Code or Codex hooks. Other platforms use the core skill without hooks.
 
 ## Works Well With
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -285,16 +285,18 @@ curl -o ~/.claude/commands/pua.md \
 
 ### OpenAI Codex CLI
 
-Codex CLI 使用相同的 Agent Skills 开放标准（SKILL.md）。Codex 版本使用精简的 description 以兼容 Codex 的长度限制：
+Codex 使用相同的 Agent Skills 开放标准（SKILL.md），并内置原生 Codex plugin manifest 与 lifecycle hooks。想要完整 v3 行为（SessionStart 注入、用户挫败触发、Bash 失败升级、PreCompact checkpoint、PUA Loop 续跑、静默可选反馈记录、Subagent 生命周期会计），请走 plugin 安装。
 
-**推荐：一键安装（git clone + symlink，支持 `git pull` 更新）**
+**推荐：源码 plugin 安装（支持 `git pull` 更新）**
 
 让 Codex 执行：
 ```
 Fetch and follow instructions from https://raw.githubusercontent.com/tanweai/pua/main/.codex/INSTALL.md
 ```
 
-**手动安装：**
+推荐安装会创建本地 Codex marketplace（`pua@pua-local`），源码放在 `~/.codex/plugins/src/pua`。不要把 plugin checkout 放在 `~/.codex/pua`；这个旧路径可能会被 Codex 当成额外 skill 源，导致 `$pua-*` 在选择器里重复出现。
+
+**手动 skill-only fallback：**
 
 ```bash
 mkdir -p ~/.codex/skills/pua
@@ -310,9 +312,12 @@ curl -o ~/.codex/prompts/pua.md \
 
 | 方式 | 命令 | 需要 |
 |------|------|------|
-| 自动触发 | 无需操作，根据 description 匹配 | SKILL.md |
-| 直接调用 | 对话中输入 `$pua` | SKILL.md |
-| 手动 prompt | 对话中输入 `/prompts:pua` | SKILL.md + prompts/pua.md |
+| Hook 触发 | 无需操作 | Codex plugin + trusted hooks |
+| 直接调用 | 对话中输入 `$pua` / `$pua-p7` / `$pua-loop` | Codex skills |
+| 文本命令 | 输入 `/pua:on`、`/pua p9`、`/pua loop ...` | Codex plugin hooks |
+| 手动 prompt | 输入 `/prompts:pua` | prompts fallback |
+
+Codex hooks 是 plugin 级 lifecycle hooks。`pua@pua-local` 安装并在 `/hooks` 里批准后，同一套 hooks 会在新会话第一轮之前和后续生命周期事件中运行。选择 `$pua-p7`、`$pua-kpi` 等 skill 只会改变当前 turn 的说明，不会安装各自独立的一套 hooks。
 
 项目级安装（仅当前项目生效）：
 
@@ -598,7 +603,7 @@ High-Agency = 外部压力 + 内在驱动（核反应堆 — 自维持链式反�
 
 > High-Agency 特性已内置于当前 pua skill，安装 pua 即可使用，无需额外操作。
 
-## 方法论智能路由：PUA v3（Claude Code）
+## 方法论智能路由：PUA v3（Claude Code + Codex Hooks）
 
 **v3 = v2 + 智能方法论路由 + 代码级行为检测**
 
@@ -620,7 +625,7 @@ v2 用压力旁白激励 Agent。v3 更进一步：自动根据任务类型选�
 - 质量差 → ⬜ Jobs → 🟧 小米 → 🟤 Netflix
 - 没搜就猜 → ⚫ 百度 → 🔶 Amazon → 🟡 字节
 
-### v3 Hook 系统（Claude Code 专属）
+### v3 Hook 系统（Claude Code + Codex Hooks）
 
 | Hook | 触发时机 | 功能 |
 |------|---------|------|
@@ -629,7 +634,7 @@ v2 用压力旁白激励 Agent。v3 更进一步：自动根据任务类型选�
 | **UserPromptSubmit** | 用户挫败短语 | 在模型响应前拦截"又错了""try harder"等，注入经过过滤的 PUA 上下文 |
 | **PreCompact** | 上下文压缩前 | 保存压力等级+失败次数，跨压缩恢复 |
 
-> v3 hook 功能需要 Claude Code。其他平台使用核心 skill，不含 hook。
+> v3 hook 功能需要 Claude Code 或 Codex hooks。其他非 Claude/Codex 平台默认使用核心 skill，不含 hook。
 
 ## 搭配使用
 
@@ -645,7 +650,7 @@ v2 用压力旁白激励 Agent。v3 更进一步：自动根据任务类型选�
 | 平台 | 自动触发 | 手动触发 |
 |------|---------|---------|
 | **Claude Code** | 是（skill description 匹配） | 见下方命令列表 |
-| **Codex CLI** | 是（skill description 匹配） | `$pua` 或 `/prompts:pua` |
+| **Codex CLI** | 是（skill description 匹配 + hooks） | `$pua`、`$pua-*`、`/pua:*` 或 `/prompts:pua` |
 | **Cursor** | 是（`.mdc` 规则，Agent Discretion） | — （仅自动） |
 | **Kiro** | 是（steering 文件或 skill） | — （仅自动） |
 | **CodeBuddy** | 是（skill description 匹配） | 插件命令（同 Claude Code） |
@@ -654,9 +659,9 @@ v2 用压力旁白激励 Agent。v3 更进一步：自动根据任务类型选�
 | **OpenCode** | 是（skill description 匹配） | — |
 | **VSCode Copilot** | 是（instructions 文件） | Copilot Chat 输入 `/pua` |
 
-> **注意：** p7/p9/p10/pro/yes/pua-loop 等子模式为 **Claude Code 专属**——其他平台仅安装核心 skill。
+> **注意：** 完整 v3 hooks 和子模式支持 Claude Code 与 Codex。其他平台仅安装核心 skill，除非对应 adapter 另有说明。
 
-### 架构（Claude Code）
+### 架构（Claude Code + Codex）
 
 ```
 /pua:pua        → 核心引擎 — 三条红线 + 味道 + 压力升级 + 方法论路由 (v3)
@@ -671,18 +676,18 @@ v2 用压力旁白激励 Agent。v3 更进一步：自动根据任务类型选�
 /pua:pua-en     → 英文 PIP 版
 /pua:pua-ja     → 日本語版
 
-Hooks（v3，Claude Code 专属）：
+Hooks（v3，Claude Code + Codex）：
   SessionStart  → additionalContext 注入（味道 + 方法论 + 路由）
   PostToolUse   → Bash 失败检测 → L1-L4 压力升级 + 方法论切换
   UserPromptSubmit → 脚本内挫败关键词过滤 → PUA 上下文
   PreCompact    → 状态持久化（压力等级 + 失败次数）
-  Stop          → 反馈收集 + PUA Loop 延续
+  Stop          → PUA Loop 延续 + 静默可选反馈记录
   SubagentStop  → Agent 生命周期会计（v3.2）— 写 teardown.jsonl，从 active-agents.json 移除
 ```
 
-### 命令（Claude Code 专属）
+### 命令（Claude Code + Codex）
 
-> **注意：** p7/p9/p10/pro/yes/pua-loop 等子模式为 Claude Code 专属。
+> **注意：** Codex 会把这些能力暴露为 `$pua-*` skills，同时通过 Codex UserPromptSubmit hook 接受 `/pua:*` 文本命令。
 >
 > 每个子命令有两种等价调用方式：独立命令（`/pua:on`）或通过主命令传参（`/pua:pua on`），效果完全相同。
 

--- a/codex/pua-cancel-loop/SKILL.md
+++ b/codex/pua-cancel-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua-cancel-loop
-description: "PUA cancel loop alias for Codex. Codex subcommand mapping for Claude Code /pua:cancel-loop style usage; invoke with $pua-cancel-loop."
+description: "Cancel the active PUA loop and remove its state file."
 license: MIT
 ---
 

--- a/codex/pua-cancel-pua-loop/SKILL.md
+++ b/codex/pua-cancel-pua-loop/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: pua-cancel-pua-loop
+description: "Cancel the active PUA loop and remove its state file."
+license: MIT
+---
+
+# pua-cancel-pua-loop
+
+This is a Codex alias for the Claude Code `/pua:cancel-pua-loop` command.
+
+Cancel the active PUA Loop by cleaning `~/.pua/loop-*.md`, compatible legacy `~/.claude/pua/loop-*.md`, local loop history state, and active-agent records. Record the teardown event before reporting completion.

--- a/codex/pua-flavor/SKILL.md
+++ b/codex/pua-flavor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua-flavor
-description: "PUA flavor alias for Codex. Codex subcommand mapping for Claude Code /pua:flavor style usage; invoke with $pua-flavor."
+description: "Switch PUA corporate flavor and methodology."
 license: MIT
 ---
 

--- a/codex/pua-kpi/SKILL.md
+++ b/codex/pua-kpi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua-kpi
-description: "PUA KPI alias for Codex. Codex subcommand mapping for Claude Code /pua:kpi style usage; invoke with $pua-kpi."
+description: "Generate a local PUA KPI report card."
 license: MIT
 ---
 

--- a/codex/pua-loop/SKILL.md
+++ b/codex/pua-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua-loop
-description: "PUA Loop alias for Codex. Codex subcommand mapping for Claude Code /pua:loop style usage; invoke with $pua-loop."
+description: "Auto-iterate until verified, paused, or aborted."
 license: MIT
 ---
 

--- a/codex/pua-mama/SKILL.md
+++ b/codex/pua-mama/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua-mama
-description: "PUA mama alias for Codex. Codex subcommand mapping for Claude Code /pua:mama style usage; invoke with $pua-mama."
+description: "Chinese mom reminder mode with the same PUA completion rules."
 license: MIT
 ---
 

--- a/codex/pua-off/SKILL.md
+++ b/codex/pua-off/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua-off
-description: "PUA off alias for Codex. Codex subcommand mapping for Claude Code /pua:off style usage; invoke with $pua-off."
+description: "Turn off always-on PUA mode and request feedback."
 license: MIT
 ---
 

--- a/codex/pua-offline/SKILL.md
+++ b/codex/pua-offline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua-offline
-description: "PUA offline alias for Codex. Codex subcommand mapping for Claude Code /pua:offline style usage; invoke with $pua-offline."
+description: "Keep PUA local while disabling network feedback flows."
 license: MIT
 ---
 

--- a/codex/pua-on/SKILL.md
+++ b/codex/pua-on/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua-on
-description: "PUA on alias for Codex. Codex subcommand mapping for Claude Code /pua:on style usage; invoke with $pua-on."
+description: "Enable always-on PUA mode for future sessions."
 license: MIT
 ---
 

--- a/codex/pua-p10/SKILL.md
+++ b/codex/pua-p10/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua-p10
-description: "PUA P10 alias for Codex. Codex subcommand mapping for Claude Code /pua:p10 style usage; invoke with $pua-p10."
+description: "P10 strategy mode: set direction, tradeoffs, and acceptance."
 license: MIT
 ---
 

--- a/codex/pua-p7/SKILL.md
+++ b/codex/pua-p7/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua-p7
-description: "PUA P7 alias for Codex. Codex subcommand mapping for Claude Code /pua:p7 style usage; invoke with $pua-p7."
+description: "P7 senior engineer mode: plan, execute, verify, and report evidence."
 license: MIT
 ---
 

--- a/codex/pua-p9/SKILL.md
+++ b/codex/pua-p9/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua-p9
-description: "PUA P9 alias for Codex. Codex subcommand mapping for Claude Code /pua:p9 style usage; invoke with $pua-p9."
+description: "P9 tech lead mode: decompose work and drive delivery."
 license: MIT
 ---
 

--- a/codex/pua-pro/SKILL.md
+++ b/codex/pua-pro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua-pro
-description: "PUA Pro alias for Codex. Codex subcommand mapping for Claude Code /pua:pro style usage; invoke with $pua-pro."
+description: "Self-evolution mode with KPI tracking and improvement loops."
 license: MIT
 ---
 

--- a/codex/pua-reap-orphans/SKILL.md
+++ b/codex/pua-reap-orphans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua-reap-orphans
-description: "PUA reap-orphans alias for Codex. Codex subcommand mapping for Claude Code /pua:reap-orphans style usage; invoke with $pua-reap-orphans."
+description: "Clean up stale PUA agent state."
 license: MIT
 ---
 

--- a/codex/pua-shot/SKILL.md
+++ b/codex/pua-shot/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: pua-shot
+description: "Single-file concentrated PUA protocol for sub-agent injection."
+license: MIT
+---
+
+# pua-shot
+
+This is a Codex alias for the Claude Code `/pua:shot` command.
+
+Load and follow `skills/shot/SKILL.md`: the concentrated single-file PUA protocol for sub-agent injection. Keep the same evidence-first completion bar as the main PUA skill.

--- a/codex/pua-survey/SKILL.md
+++ b/codex/pua-survey/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua-survey
-description: "PUA survey alias for Codex. Codex subcommand mapping for Claude Code /pua:survey style usage; invoke with $pua-survey."
+description: "Run the PUA research questionnaire."
 license: MIT
 ---
 

--- a/codex/pua-team-status/SKILL.md
+++ b/codex/pua-team-status/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua-team-status
-description: "PUA team status alias for Codex. Codex subcommand mapping for Claude Code /pua:team-status style usage; invoke with $pua-team-status."
+description: "Show active PUA agent team status."
 license: MIT
 ---
 

--- a/codex/pua-teardown-all/SKILL.md
+++ b/codex/pua-teardown-all/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua-teardown-all
-description: "PUA teardown alias for Codex. Codex subcommand mapping for Claude Code /pua:teardown-all style usage; invoke with $pua-teardown-all."
+description: "Stop and clean up all PUA agent team state."
 license: MIT
 ---
 

--- a/codex/pua-yes/SKILL.md
+++ b/codex/pua-yes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua-yes
-description: "PUA yes alias for Codex. Codex subcommand mapping for Claude Code /pua:yes style usage; invoke with $pua-yes."
+description: "Encouragement mode: supportive pressure with light roasting."
 license: MIT
 ---
 

--- a/commands/pua.md
+++ b/commands/pua.md
@@ -1,5 +1,5 @@
 ---
-description: "Use when the user invokes /pua or asks for PUA mode, try-harder/retry help, change-approach coaching, completion-quality checks, evidence requests, test-before-done reminders, or Ding-style workplace reminders. Routes to p7, p9, p10, pro, yes, mama, loop, on/off/offline, kpi, survey, flavor, ding, again, done-check, or evidence. Normal calm first-attempt requests are left alone."
+description: "Use only when the user explicitly invokes /pua or asks for PUA mode, try-harder/retry help, change-approach coaching, completion-quality checks, evidence requests, test-before-done reminders, or Ding-style workplace reminders. Routes to p7, p9, p10, pro, yes, mama, loop, on/off/offline, kpi, survey, flavor, ding, again, done-check, or evidence. Normal calm first-attempt requests are left alone."
 argument-hint: "[p7|p9|p10|pro|yes|mama|loop|on|off|offline|kpi|survey|flavor|ding|again|done-check|evidence|task]"
 ---
 

--- a/evals/run-trigger-test.sh
+++ b/evals/run-trigger-test.sh
@@ -33,7 +33,7 @@ test_prompt() {
 
     (
         cd "$EVAL_WORKSPACE"
-        PUA_CONFIG="$EVAL_PUA_CONFIG" PUA_FORCE_ON=1 run_with_timeout 120 claude -p "$prompt" \
+        PUA_FORCE_ON=1 PUA_CONFIG="$EVAL_PUA_CONFIG" run_with_timeout 120 claude -p "$prompt" \
             --plugin-dir "$PLUGIN_DIR" \
             --dangerously-skip-permissions \
             --max-turns 2 \

--- a/evals/test-release-consistency.sh
+++ b/evals/test-release-consistency.sh
@@ -13,6 +13,7 @@ manifest_files = [
     '.claude-plugin/marketplace.json',
     '.codebuddy-plugin/plugin.json',
     '.codebuddy-plugin/marketplace.json',
+    '.codex-plugin/plugin.json',
 ]
 versions = []
 errors = []
@@ -73,6 +74,42 @@ else:
             errors.append(f'harness governance reference missing required term: {term}')
 
 hooks_json = json.loads((root / 'hooks/hooks.json').read_text(encoding='utf-8'))
+codex_plugin = json.loads((root / '.codex-plugin/plugin.json').read_text(encoding='utf-8'))
+if codex_plugin.get('skills') != './codex/':
+    errors.append('.codex-plugin/plugin.json must point skills at ./codex/')
+if codex_plugin.get('hooks') != './hooks/codex-hooks.json':
+    errors.append('.codex-plugin/plugin.json must point hooks at ./hooks/codex-hooks.json')
+codex_hooks_path = root / 'hooks/codex-hooks.json'
+if not codex_hooks_path.exists():
+    errors.append('missing hooks/codex-hooks.json')
+else:
+    codex_hooks = json.loads(codex_hooks_path.read_text(encoding='utf-8'))
+    def walk_hooks(obj):
+        if isinstance(obj, dict):
+            if obj.get('type') == 'prompt':
+                errors.append('Codex hooks must not use type: prompt')
+            for value in obj.values():
+                walk_hooks(value)
+        elif isinstance(obj, list):
+            for value in obj:
+                walk_hooks(value)
+    walk_hooks(codex_hooks)
+    for event in ['SessionStart', 'UserPromptSubmit', 'PostToolUse', 'PreCompact', 'Stop', 'SubagentStart', 'SubagentStop', 'PreToolUse']:
+        if event not in codex_hooks.get('hooks', {}):
+            errors.append(f'Codex hooks missing event: {event}')
+for rel in [
+    'hooks/codex-context-wrapper.sh',
+    'hooks/codex-command-router.sh',
+    'hooks/codex-precompact-checkpoint.sh',
+    'hooks/codex-stop-dispatcher.sh',
+    'hooks/codex-stop-feedback.sh',
+    'hooks/codex-feedback-submit.sh',
+    'hooks/codex-subagent-start.sh',
+    'codex/pua-shot/SKILL.md',
+    'codex/pua-cancel-pua-loop/SKILL.md',
+]:
+    if not (root / rel).exists():
+        errors.append(f'missing Codex hook/alias asset: {rel}')
 pre_hooks = hooks_json.get('hooks', {}).get('PreToolUse', [])
 if not any(any('integrity-guard.sh' in hook.get('command', '') for hook in item.get('hooks', [])) for item in pre_hooks):
     errors.append('hooks/hooks.json missing PreToolUse integrity-guard.sh registration')
@@ -248,6 +285,14 @@ if 'EVAL_WORKSPACE="$RESULTS_DIR/workspace"' not in trigger or 'cd "$EVAL_WORKSP
     errors.append('trigger eval must run in a neutral workspace, not the pua plugin repo')
 if 'PUA_CONFIG="$eval_config" run_with_timeout 90 claude' not in helpers:
     errors.append('behavior eval must use isolated PUA_CONFIG to avoid user ~/.pua/config.json')
+
+readme_en = (root / 'README.md').read_text(encoding='utf-8')
+readme_zh = (root / 'README.zh-CN.md').read_text(encoding='utf-8')
+for text, label in [(readme_en, 'README.md'), (readme_zh, 'README.zh-CN.md')]:
+    if 'Codex hooks' not in text and 'Codex Hook' not in text:
+        errors.append(f'{label} must document Codex hooks support')
+    if 'other platforms install the core skill only' in text or '其他平台使用核心 skill，不含 hook' in text:
+        errors.append(f'{label} still claims Codex lacks hook/sub-mode support')
 
 if errors:
     print('=== Release consistency FAILED ===')

--- a/hooks/codex-command-router.sh
+++ b/hooks/codex-command-router.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# Codex UserPromptSubmit router for /pua:* and pending feedback replies.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+source "${SCRIPT_DIR}/flavor-helper.sh"
+
+PUA_PY="$(pua_python_cmd 2>/dev/null || true)"
+[[ -z "$PUA_PY" ]] && exit 0
+
+HOOK_INPUT=$(cat || true)
+PROMPT=$(printf '%s' "$HOOK_INPUT" | "$PUA_PY" -c 'import json,sys
+try:
+    data=json.load(sys.stdin)
+    print(data.get("prompt") or data.get("message") or data.get("user_prompt") or "")
+except Exception:
+    print(sys.stdin.read())' 2>/dev/null || true)
+
+json_context() {
+  "$PUA_PY" - "$1" <<'PY'
+import json, sys
+print(json.dumps({"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":sys.argv[1]}}, ensure_ascii=False))
+PY
+}
+
+update_config() {
+  local mode="$1"
+  local value="${2:-}"
+  local config
+  config="$(pua_config_file)"
+  mkdir -p "$(dirname "$config")"
+  "$PUA_PY" - "$config" "$mode" "$value" <<'PY'
+import json, os, sys
+path, mode, value = sys.argv[1:4]
+try:
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+except Exception:
+    data = {}
+
+if mode == "on":
+    data["always_on"] = True
+    if str(data.get("feedback_frequency", "")).lower() in {"0", "off", "never"}:
+        data["feedback_frequency"] = 5
+elif mode == "off":
+    data["always_on"] = False
+    data["feedback_frequency"] = 0
+elif mode == "offline":
+    data["offline"] = True
+    data["feedback_frequency"] = 0
+elif mode == "flavor" and value:
+    data["flavor"] = value
+
+tmp = path + ".tmp"
+with open(tmp, "w", encoding="utf-8") as f:
+    json.dump(data, f, ensure_ascii=False, indent=2)
+    f.write("\n")
+os.replace(tmp, path)
+PY
+}
+
+handle_feedback_reply() {
+  local pending="${HOME:-~}/.pua/pending-feedback.json"
+  [[ ! -f "$pending" ]] && return 1
+  case "$PROMPT" in
+    *"pua feedback skip"*|*"这次跳过"*|*"跳过"*|*"skip"*)
+      mkdir -p "${HOME:-~}/.pua"
+      printf '{"ts":"%s","rating":"skip","uploaded":false}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${HOME:-~}/.pua/feedback.jsonl"
+      rm -f "$pending"
+      json_context "[PUA Feedback] Skipped and recorded locally. Continue the user's task normally."
+      return 0
+      ;;
+    *"pua feedback useful upload"*|*"上传评分 + 脱敏 session"*|*"上传脱敏"*|*"upload session"*)
+      bash "${SCRIPT_DIR}/codex-feedback-submit.sh" useful_upload
+      return 0
+      ;;
+    *"pua feedback useful"*|*"很有用"*|*"useful"*)
+      bash "${SCRIPT_DIR}/codex-feedback-submit.sh" useful
+      return 0
+      ;;
+    *"pua feedback ok"*|*"一般般"*|*"ok"*)
+      bash "${SCRIPT_DIR}/codex-feedback-submit.sh" ok
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+handle_feedback_reply && exit 0
+
+COMMAND=$("$PUA_PY" - "$PROMPT" <<'PY'
+import re, sys
+prompt = sys.argv[1].strip()
+patterns = [
+    r"^/pua(?::(?P<cmd>[A-Za-z0-9_-]+))?(?:\s+(?P<rest>.*))?$",
+    r"^/pua\s+(?P<cmd2>[A-Za-z0-9_-]+)(?:\s+(?P<rest2>.*))?$",
+]
+for pat in patterns:
+    m = re.match(pat, prompt)
+    if m:
+        cmd = m.groupdict().get("cmd") or m.groupdict().get("cmd2") or "pua"
+        rest = m.groupdict().get("rest") if m.groupdict().get("rest") is not None else m.groupdict().get("rest2") or ""
+        if cmd == "pua" and rest:
+            first, _, tail = rest.partition(" ")
+            if first in {"pua","p7","p9","p10","pro","yes","mama","shot","pua-loop","loop","on","off","offline","survey","flavor","kpi","cancel-pua-loop","cancel-loop","team-status","reap-orphans","teardown-all","pua-en","pua-ja","en","ja"}:
+                cmd, rest = first, tail
+        print(cmd + "\t" + rest)
+        break
+PY
+)
+
+[[ -z "$COMMAND" ]] && exit 0
+
+CMD="${COMMAND%%	*}"
+REST="${COMMAND#*	}"
+
+case "$CMD" in
+  loop) CMD="pua-loop" ;;
+  cancel-loop) CMD="cancel-pua-loop" ;;
+  en) CMD="pua-en" ;;
+  ja) CMD="pua-ja" ;;
+esac
+
+case "$CMD" in
+  on)
+    update_config on
+    json_context "[PUA ON] Always-on mode enabled for Codex. Future sessions will receive PUA SessionStart context."
+    ;;
+  off)
+    update_config off
+    json_context "[PUA OFF] Always-on mode and feedback prompts disabled for Codex."
+    ;;
+  offline)
+    update_config offline
+    json_context "[PUA OFFLINE] Offline mode enabled. Local PUA behavior stays on; feedback, upload, leaderboard, and heartbeat network flows stay off."
+    ;;
+  flavor)
+    if [[ -n "$REST" ]]; then
+      update_config flavor "$REST"
+      json_context "[PUA Flavor] Flavor set to ${REST}. Preserve this flavor in PUA reminders."
+    else
+      json_context "User invoked /pua:flavor. Use the \$pua-flavor skill to show the 14 corporate flavors and help choose one."
+    fi
+    ;;
+  pua-loop)
+    if [[ -z "$REST" ]]; then
+      json_context "User invoked /pua:pua-loop without arguments. Ask for the loop task, optional --verify command, and optional --completion-promise."
+      exit 0
+    fi
+    LOOP_OUTPUT=$(PUA_PLUGIN_ROOT="$PLUGIN_ROOT" "$PUA_PY" - "$REST" "$PLUGIN_ROOT/scripts/setup-pua-loop.sh" <<'PY'
+import os, shlex, subprocess, sys
+rest, script = sys.argv[1], sys.argv[2]
+try:
+    args = shlex.split(rest)
+except ValueError as exc:
+    print(f"[PUA Loop] Could not parse arguments: {exc}")
+    raise SystemExit(0)
+env = os.environ.copy()
+env.setdefault("PUA_RUNTIME", "codex")
+proc = subprocess.run(["bash", script, *args], text=True, capture_output=True, env=env)
+out = (proc.stdout + ("\n" + proc.stderr if proc.stderr else "")).strip()
+print(out)
+PY
+)
+    json_context "${LOOP_OUTPUT:-[PUA Loop] Activated. Continue the loop task under the PUA Loop protocol.}"
+    ;;
+  pua|p7|p9|p10|pro|yes|mama|shot|pua-en|pua-ja|survey|kpi|team-status|reap-orphans|teardown-all|cancel-pua-loop)
+    SKILL="$CMD"
+    case "$CMD" in
+      pua) SKILL="pua" ;;
+      p7|p9|p10|pro|yes|mama) SKILL="pua-$CMD" ;;
+      shot) SKILL="pua-shot" ;;
+      pua-en|pua-ja) SKILL="$CMD" ;;
+      cancel-pua-loop) SKILL="pua-cancel-pua-loop" ;;
+      *) SKILL="pua-$CMD" ;;
+    esac
+    json_context "User invoked /pua:${CMD}. Use the \$${SKILL} Codex skill semantics for this turn. Arguments: ${REST:-none}"
+    ;;
+  *)
+    json_context "User invoked /pua:${CMD}. Route through \$pua if no narrower PUA Codex skill exists. Arguments: ${REST:-none}"
+    ;;
+esac

--- a/hooks/codex-command-router.sh
+++ b/hooks/codex-command-router.sh
@@ -10,6 +10,7 @@ PUA_PY="$(pua_python_cmd 2>/dev/null || true)"
 [[ -z "$PUA_PY" ]] && exit 0
 
 HOOK_INPUT=$(cat || true)
+PUA_DIR="$(pua_state_dir)"
 PROMPT=$(printf '%s' "$HOOK_INPUT" | "$PUA_PY" -c 'import json,sys
 try:
     data=json.load(sys.stdin)
@@ -61,12 +62,12 @@ PY
 }
 
 handle_feedback_reply() {
-  local pending="${HOME:-~}/.pua/pending-feedback.json"
+  local pending="${PUA_DIR}/pending-feedback.json"
   [[ ! -f "$pending" ]] && return 1
   case "$PROMPT" in
     *"pua feedback skip"*|*"这次跳过"*|*"跳过"*|*"skip"*)
-      mkdir -p "${HOME:-~}/.pua"
-      printf '{"ts":"%s","rating":"skip","uploaded":false}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${HOME:-~}/.pua/feedback.jsonl"
+      mkdir -p "$PUA_DIR"
+      printf '{"ts":"%s","rating":"跳过","choice":"skip","pua_count":1,"uploaded":false}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${PUA_DIR}/feedback.jsonl"
       rm -f "$pending"
       json_context "[PUA Feedback] Skipped and recorded locally. Continue the user's task normally."
       return 0

--- a/hooks/codex-context-wrapper.sh
+++ b/hooks/codex-context-wrapper.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Wrap legacy text-producing PUA hooks as Codex additionalContext JSON.
+set -uo pipefail
+
+HOOK_EVENT="${1:-}"
+shift || true
+
+if [[ -z "$HOOK_EVENT" || $# -eq 0 ]]; then
+  exit 0
+fi
+
+HOOK_INPUT=$(cat || true)
+set +e
+OUTPUT=$(printf '%s' "$HOOK_INPUT" | "$@" 2>/dev/null)
+STATUS=$?
+set -e
+
+if [[ $STATUS -ne 0 || -z "$OUTPUT" ]]; then
+  exit 0
+fi
+
+if printf '%s' "$OUTPUT" | python3 -c 'import json,sys; data=json.load(sys.stdin); raise SystemExit(0 if isinstance(data,dict) and ("hookSpecificOutput" in data or "decision" in data) else 1)' >/dev/null 2>&1; then
+  printf '%s\n' "$OUTPUT"
+  exit 0
+fi
+
+python3 - "$HOOK_EVENT" "$OUTPUT" <<'PY'
+import json, sys
+event, text = sys.argv[1], sys.argv[2]
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": event,
+        "additionalContext": text,
+    }
+}, ensure_ascii=False))
+PY

--- a/hooks/codex-feedback-submit.sh
+++ b/hooks/codex-feedback-submit.sh
@@ -8,7 +8,7 @@ PUA_PY="$(pua_python_cmd 2>/dev/null || true)"
 [[ -z "$PUA_PY" ]] && exit 0
 
 CHOICE="${1:-skip}"
-PUA_DIR="${HOME:-~}/.pua"
+PUA_DIR="$(pua_state_dir)"
 PENDING="${PUA_DIR}/pending-feedback.json"
 CONFIG="$(pua_config_file)"
 mkdir -p "$PUA_DIR"
@@ -44,20 +44,29 @@ except Exception:
 PY
 )
 
-RATING="很有用"
-[[ "$CHOICE" = "ok" ]] && RATING="一般般"
+case "$CHOICE" in
+  ok) RATING="一般般" ;;
+  skip) RATING="跳过" ;;
+  *) RATING="很有用" ;;
+esac
 
 UPLOAD_OK=false
-if command -v curl >/dev/null 2>&1; then
+if [[ "$CHOICE" != "skip" ]] && command -v curl >/dev/null 2>&1; then
+  PAYLOAD=$("$PUA_PY" - "$RATING" "$FLAVOR" <<'PY'
+import json, sys
+rating, flavor = sys.argv[1:3]
+print(json.dumps({"rating": rating, "pua_count": 1, "flavor": flavor, "task_summary": "codex feedback"}, ensure_ascii=False))
+PY
+)
   curl -sS --max-time 10 -X POST https://pua-skill.pages.dev/api/feedback \
     -H "Content-Type: application/json" \
-    -d "{\"rating\":\"$RATING\",\"pua_count\":1,\"flavor\":\"$FLAVOR\",\"task_summary\":\"codex feedback\"}" >/dev/null 2>&1 && UPLOAD_OK=true || true
+    -d "$PAYLOAD" >/dev/null 2>&1 && UPLOAD_OK=true || true
 fi
 
-if [[ "$CHOICE" = "useful_upload" && -f "$TRANSCRIPT_PATH" && -f "${SCRIPT_DIR}/sanitize-session.sh" ]]; then
+if [[ "$CHOICE" = "useful_upload" ]] && [[ -f "$TRANSCRIPT_PATH" ]] && [[ -f "${SCRIPT_DIR}/sanitize-session.sh" ]]; then
   SANITIZED="${PUA_DIR}/pua-sanitized-session.jsonl"
   bash "${SCRIPT_DIR}/sanitize-session.sh" "$TRANSCRIPT_PATH" "$SANITIZED" >/dev/null 2>&1 || true
-  if [[ -f "$SANITIZED" && command -v curl >/dev/null 2>&1 ]]; then
+  if [[ -f "$SANITIZED" ]] && command -v curl >/dev/null 2>&1; then
     curl -sS --max-time 30 -X POST https://pua-skill.pages.dev/api/upload \
       -H "Content-Type: application/jsonl; charset=utf-8" \
       -H "X-PUA-File-Name: $(basename "$SANITIZED")" \
@@ -67,6 +76,18 @@ if [[ "$CHOICE" = "useful_upload" && -f "$TRANSCRIPT_PATH" && -f "${SCRIPT_DIR}/
   fi
 fi
 
-printf '{"ts":"%s","choice":"%s","uploaded":%s,"flavor":"%s"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$CHOICE" "$UPLOAD_OK" "$FLAVOR" >> "${PUA_DIR}/feedback.jsonl"
+"$PUA_PY" - "${PUA_DIR}/feedback.jsonl" "$CHOICE" "$RATING" "$UPLOAD_OK" "$FLAVOR" <<'PY'
+import json, sys, time
+path, choice, rating, uploaded, flavor = sys.argv[1:6]
+with open(path, "a", encoding="utf-8") as f:
+    f.write(json.dumps({
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "rating": rating,
+        "choice": choice,
+        "pua_count": 1,
+        "uploaded": uploaded == "true",
+        "flavor": flavor,
+    }, ensure_ascii=False, separators=(",", ":")) + "\n")
+PY
 rm -f "$PENDING"
 json_context "[PUA Feedback] Consent handled. rating_uploaded=${UPLOAD_OK}. Continue normally."

--- a/hooks/codex-feedback-submit.sh
+++ b/hooks/codex-feedback-submit.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Submit a pending Codex PUA feedback choice after explicit user consent.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/flavor-helper.sh"
+PUA_PY="$(pua_python_cmd 2>/dev/null || true)"
+[[ -z "$PUA_PY" ]] && exit 0
+
+CHOICE="${1:-skip}"
+PUA_DIR="${HOME:-~}/.pua"
+PENDING="${PUA_DIR}/pending-feedback.json"
+CONFIG="$(pua_config_file)"
+mkdir -p "$PUA_DIR"
+
+json_context() {
+  "$PUA_PY" - "$1" <<'PY'
+import json, sys
+print(json.dumps({"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":sys.argv[1]}}, ensure_ascii=False))
+PY
+}
+
+[[ ! -f "$PENDING" ]] && { json_context "[PUA Feedback] No pending feedback request."; exit 0; }
+if [[ -f "$CONFIG" && "$(pua_json_get "$CONFIG" offline False)" = "True" ]]; then
+  json_context "[PUA Feedback] Offline mode is enabled; upload skipped."
+  rm -f "$PENDING"
+  exit 0
+fi
+
+TRANSCRIPT_PATH=$("$PUA_PY" - "$PENDING" <<'PY'
+import json, sys
+try:
+    print(json.load(open(sys.argv[1], encoding="utf-8")).get("transcript_path",""))
+except Exception:
+    print("")
+PY
+)
+FLAVOR=$("$PUA_PY" - "$PENDING" <<'PY'
+import json, sys
+try:
+    print(json.load(open(sys.argv[1], encoding="utf-8")).get("flavor","alibaba"))
+except Exception:
+    print("alibaba")
+PY
+)
+
+RATING="很有用"
+[[ "$CHOICE" = "ok" ]] && RATING="一般般"
+
+UPLOAD_OK=false
+if command -v curl >/dev/null 2>&1; then
+  curl -sS --max-time 10 -X POST https://pua-skill.pages.dev/api/feedback \
+    -H "Content-Type: application/json" \
+    -d "{\"rating\":\"$RATING\",\"pua_count\":1,\"flavor\":\"$FLAVOR\",\"task_summary\":\"codex feedback\"}" >/dev/null 2>&1 && UPLOAD_OK=true || true
+fi
+
+if [[ "$CHOICE" = "useful_upload" && -f "$TRANSCRIPT_PATH" && -f "${SCRIPT_DIR}/sanitize-session.sh" ]]; then
+  SANITIZED="${PUA_DIR}/pua-sanitized-session.jsonl"
+  bash "${SCRIPT_DIR}/sanitize-session.sh" "$TRANSCRIPT_PATH" "$SANITIZED" >/dev/null 2>&1 || true
+  if [[ -f "$SANITIZED" && command -v curl >/dev/null 2>&1 ]]; then
+    curl -sS --max-time 30 -X POST https://pua-skill.pages.dev/api/upload \
+      -H "Content-Type: application/jsonl; charset=utf-8" \
+      -H "X-PUA-File-Name: $(basename "$SANITIZED")" \
+      -H "X-PUA-Wechat-Id: not-provided" \
+      -H "X-PUA-Upload-Consent: explicit" \
+      --data-binary @"$SANITIZED" >/dev/null 2>&1 || true
+  fi
+fi
+
+printf '{"ts":"%s","choice":"%s","uploaded":%s,"flavor":"%s"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$CHOICE" "$UPLOAD_OK" "$FLAVOR" >> "${PUA_DIR}/feedback.jsonl"
+rm -f "$PENDING"
+json_context "[PUA Feedback] Consent handled. rating_uploaded=${UPLOAD_OK}. Continue normally."

--- a/hooks/codex-hooks.json
+++ b/hooks/codex-hooks.json
@@ -1,0 +1,116 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "PUA_RUNTIME=codex bash \"${CLAUDE_PLUGIN_ROOT}/hooks/heartbeat.sh\"",
+            "timeout": 2,
+            "statusMessage": "PUA heartbeat"
+          },
+          {
+            "type": "command",
+            "command": "PUA_RUNTIME=codex bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-restore.sh\"",
+            "timeout": 5,
+            "statusMessage": "Loading PUA context"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "PUA_RUNTIME=codex bash \"${CLAUDE_PLUGIN_ROOT}/hooks/codex-command-router.sh\"",
+            "timeout": 10,
+            "statusMessage": "Routing PUA command"
+          },
+          {
+            "type": "command",
+            "command": "PUA_RUNTIME=codex bash \"${CLAUDE_PLUGIN_ROOT}/hooks/codex-context-wrapper.sh\" UserPromptSubmit \"${CLAUDE_PLUGIN_ROOT}/hooks/frustration-trigger.sh\"",
+            "timeout": 5,
+            "statusMessage": "Checking PUA trigger"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "PUA_RUNTIME=codex bash \"${CLAUDE_PLUGIN_ROOT}/hooks/codex-context-wrapper.sh\" PostToolUse \"${CLAUDE_PLUGIN_ROOT}/hooks/failure-detector.sh\"",
+            "timeout": 5,
+            "statusMessage": "Checking failure pattern"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "manual|auto",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "PUA_RUNTIME=codex bash \"${CLAUDE_PLUGIN_ROOT}/hooks/codex-precompact-checkpoint.sh\"",
+            "timeout": 5,
+            "statusMessage": "Saving PUA checkpoint"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "PUA_RUNTIME=codex bash \"${CLAUDE_PLUGIN_ROOT}/hooks/codex-stop-dispatcher.sh\"",
+            "timeout": 30,
+            "statusMessage": "Checking PUA loop"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "PUA_RUNTIME=codex bash \"${CLAUDE_PLUGIN_ROOT}/hooks/codex-subagent-start.sh\"",
+            "timeout": 5,
+            "statusMessage": "Tracking PUA agent"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "PUA_RUNTIME=codex bash \"${CLAUDE_PLUGIN_ROOT}/hooks/subagent-teardown.sh\"",
+            "timeout": 5,
+            "statusMessage": "Releasing PUA agent"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Read|Grep|Glob|Edit|Write|apply_patch|mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "PUA_RUNTIME=codex bash \"${CLAUDE_PLUGIN_ROOT}/hooks/integrity-guard.sh\"",
+            "timeout": 5,
+            "statusMessage": "Checking PUA guard"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/codex-precompact-checkpoint.sh
+++ b/hooks/codex-precompact-checkpoint.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Codex command hook replacement for Claude prompt-based PreCompact.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/flavor-helper.sh"
+PUA_PY="$(pua_python_cmd 2>/dev/null || true)"
+
+HOOK_INPUT=$(cat || true)
+PUA_DIR="${HOME:-~}/.pua"
+JOURNAL="${PUA_DIR}/builder-journal.md"
+CONFIG="$(pua_config_file)"
+mkdir -p "$PUA_DIR"
+
+FAILURE_COUNT=0
+[[ -f "$PUA_DIR/.failure_count" ]] && FAILURE_COUNT=$(cat "$PUA_DIR/.failure_count" 2>/dev/null || echo 0)
+PEAK_LEVEL=0
+[[ -f "$PUA_DIR/.peak_pressure_level" ]] && PEAK_LEVEL=$(cat "$PUA_DIR/.peak_pressure_level" 2>/dev/null || echo 0)
+
+get_flavor
+ALWAYS_ON=False
+[[ -f "$CONFIG" ]] && ALWAYS_ON=$(pua_json_get "$CONFIG" always_on False)
+
+TRANSCRIPT_PATH=""
+TRIGGER="unknown"
+if [[ -n "$PUA_PY" ]]; then
+  TRANSCRIPT_PATH=$(printf '%s' "$HOOK_INPUT" | "$PUA_PY" -c 'import json,sys
+try:
+    d=json.load(sys.stdin)
+    print(d.get("transcript_path",""))
+except Exception:
+    print("")' 2>/dev/null || true)
+  TRIGGER=$(printf '%s' "$HOOK_INPUT" | "$PUA_PY" -c 'import json,sys
+try:
+    d=json.load(sys.stdin)
+    print(d.get("trigger") or d.get("compact_trigger") or d.get("matcher") or "unknown")
+except Exception:
+    print("unknown")' 2>/dev/null || true)
+fi
+
+PUA_MARKERS=0
+if [[ -n "$TRANSCRIPT_PATH" && -f "$TRANSCRIPT_PATH" ]]; then
+  PUA_MARKERS=$(grep -Ec 'PUA生效|\[PUA|\[PIP-REPORT\]|\[PUA-REPORT\]|<PUA_SKILL_CONTEXT>' "$TRANSCRIPT_PATH" 2>/dev/null || echo 0)
+fi
+
+if [[ "$ALWAYS_ON" != "True" && "${FAILURE_COUNT:-0}" = "0" && "${PUA_MARKERS:-0}" = "0" ]]; then
+  exit 0
+fi
+
+cat > "$JOURNAL" <<EOF
+# PUA Builder Journal — Codex Compaction Note
+
+## Timestamp
+$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+## Runtime State
+- runtime: codex
+- compact_trigger: ${TRIGGER}
+- pressure_level: L${PEAK_LEVEL:-0}
+- failure_count: ${FAILURE_COUNT:-0}
+- current_flavor: ${PUA_FLAVOR:-alibaba}
+- transcript_markers: ${PUA_MARKERS:-0}
+
+## Next Candidate Action
+On resume, restore the current PUA flavor, review failed approaches, and require concrete verification evidence before any completion claim.
+
+## Key Context
+- transcript_path: ${TRANSCRIPT_PATH:-unknown}
+- config: ${CONFIG}
+EOF
+
+"${PUA_PY:-python3}" - "$JOURNAL" <<'PY'
+import json, sys
+path = sys.argv[1]
+print(json.dumps({"hookSpecificOutput":{"hookEventName":"PreCompact","additionalContext":f"[PUA Checkpoint] Local state note saved to {path}"}}, ensure_ascii=False))
+PY

--- a/hooks/codex-precompact-checkpoint.sh
+++ b/hooks/codex-precompact-checkpoint.sh
@@ -7,7 +7,7 @@ source "${SCRIPT_DIR}/flavor-helper.sh"
 PUA_PY="$(pua_python_cmd 2>/dev/null || true)"
 
 HOOK_INPUT=$(cat || true)
-PUA_DIR="${HOME:-~}/.pua"
+PUA_DIR="$(pua_state_dir)"
 JOURNAL="${PUA_DIR}/builder-journal.md"
 CONFIG="$(pua_config_file)"
 mkdir -p "$PUA_DIR"

--- a/hooks/codex-stop-dispatcher.sh
+++ b/hooks/codex-stop-dispatcher.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Stop hooks run concurrently in Codex. Keep PUA Loop before feedback in one dispatcher.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK_INPUT=$(cat || true)
+
+set +e
+LOOP_OUTPUT=$(printf '%s' "$HOOK_INPUT" | PUA_RUNTIME=codex bash "${SCRIPT_DIR}/pua-loop-hook.sh" 2>/dev/null)
+LOOP_STATUS=$?
+set -e
+
+if [[ $LOOP_STATUS -eq 0 && -n "$LOOP_OUTPUT" ]]; then
+  if printf '%s' "$LOOP_OUTPUT" | python3 -c 'import json,sys; data=json.load(sys.stdin); raise SystemExit(0 if data.get("decision")=="block" else 1)' >/dev/null 2>&1; then
+    printf '%s\n' "$LOOP_OUTPUT"
+    exit 0
+  fi
+fi
+
+printf '%s' "$HOOK_INPUT" | PUA_RUNTIME=codex bash "${SCRIPT_DIR}/codex-stop-feedback.sh"

--- a/hooks/codex-stop-feedback.sh
+++ b/hooks/codex-stop-feedback.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Codex Stop hook feedback bookkeeping. No visible prompt and no upload happen here.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/flavor-helper.sh"
+PUA_PY="$(pua_python_cmd 2>/dev/null || true)"
+[[ -z "$PUA_PY" ]] && exit 0
+
+HOOK_INPUT=$(cat || true)
+CONFIG="$(pua_config_file)"
+PUA_DIR="${HOME:-~}/.pua"
+COUNTER="${PUA_DIR}/.stop_counter"
+PENDING="${PUA_DIR}/pending-feedback.json"
+mkdir -p "$PUA_DIR"
+
+if [[ -f "$CONFIG" ]]; then
+  [[ "$(pua_json_get "$CONFIG" offline False)" = "True" ]] && exit 0
+  freq=$(pua_json_get "$CONFIG" feedback_frequency 5)
+  case "$freq" in
+    0|never|off) exit 0 ;;
+    1|every) FREQUENCY=1 ;;
+    *) [[ "$freq" =~ ^[0-9]+$ ]] && FREQUENCY="$freq" || FREQUENCY=5 ;;
+  esac
+else
+  FREQUENCY=5
+fi
+
+TRANSCRIPT_PATH=$(printf '%s' "$HOOK_INPUT" | "$PUA_PY" -c 'import json,sys
+try:
+    d=json.load(sys.stdin)
+    print(d.get("transcript_path",""))
+except Exception:
+    print("")' 2>/dev/null || true)
+[[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]] && exit 0
+grep -qE 'PUA生效|\[Auto-select:|\[PIP-REPORT\]|\[PUA-REPORT\]|<PUA_SKILL_CONTEXT>' "$TRANSCRIPT_PATH" 2>/dev/null || exit 0
+
+count=0
+[[ -f "$COUNTER" ]] && count=$(cat "$COUNTER" 2>/dev/null || echo 0)
+count=$((count + 1))
+echo "$count" > "$COUNTER"
+[[ $((count % FREQUENCY)) -ne 0 ]] && exit 0
+
+get_flavor
+"$PUA_PY" - "$PENDING" "$TRANSCRIPT_PATH" "${PUA_FLAVOR:-alibaba}" <<'PY'
+import json, os, sys, time
+path, transcript, flavor = sys.argv[1:4]
+tmp = path + ".tmp"
+with open(tmp, "w", encoding="utf-8") as f:
+    json.dump({"ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "transcript_path": transcript, "flavor": flavor}, f, ensure_ascii=False, indent=2)
+    f.write("\n")
+os.replace(tmp, path)
+PY
+
+exit 0

--- a/hooks/codex-stop-feedback.sh
+++ b/hooks/codex-stop-feedback.sh
@@ -9,7 +9,7 @@ PUA_PY="$(pua_python_cmd 2>/dev/null || true)"
 
 HOOK_INPUT=$(cat || true)
 CONFIG="$(pua_config_file)"
-PUA_DIR="${HOME:-~}/.pua"
+PUA_DIR="$(pua_state_dir)"
 COUNTER="${PUA_DIR}/.stop_counter"
 PENDING="${PUA_DIR}/pending-feedback.json"
 mkdir -p "$PUA_DIR"

--- a/hooks/codex-subagent-start.sh
+++ b/hooks/codex-subagent-start.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Codex SubagentStart accounting for PUA team status.
+set -uo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+HOOK_INPUT=$(cat || true)
+PUA_DIR="${PUA_STATE_DIR:-${HOME}/.pua}"
+mkdir -p "$PUA_DIR" 2>/dev/null || exit 0
+
+AGENT_ID=$(printf '%s' "$HOOK_INPUT" | jq -r '.agent_id // .subagent_id // .thread_id // ""' 2>/dev/null || echo "")
+AGENT_TYPE=$(printf '%s' "$HOOK_INPUT" | jq -r '.agent_type // .subagent_type // .type // "codex-subagent"' 2>/dev/null || echo "codex-subagent")
+SESSION_ID=$(printf '%s' "$HOOK_INPUT" | jq -r '.session_id // ""' 2>/dev/null || echo "")
+[[ -z "$AGENT_ID" ]] && AGENT_ID="codex-$(date +%s)-$$"
+
+ACTIVE_FILE="$PUA_DIR/active-agents.json"
+TMP="$ACTIVE_FILE.tmp.$$"
+if [[ ! -f "$ACTIVE_FILE" ]]; then
+  printf '{"agents":[]}\n' > "$ACTIVE_FILE"
+fi
+
+jq \
+  --arg id "$AGENT_ID" \
+  --arg type "$AGENT_TYPE" \
+  --arg session "$SESSION_ID" \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  '.agents = ((.agents // []) | map(select(.id != $id)) + [{id:$id,type:$type,parent_session:$session,spawn_time:$ts,runtime:"codex"}])' \
+  "$ACTIVE_FILE" > "$TMP" 2>/dev/null && mv "$TMP" "$ACTIVE_FILE" || rm -f "$TMP"
+
+exit 0

--- a/hooks/codex-subagent-start.sh
+++ b/hooks/codex-subagent-start.sh
@@ -2,9 +2,11 @@
 # Codex SubagentStart accounting for PUA team status.
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/flavor-helper.sh"
 command -v jq >/dev/null 2>&1 || exit 0
 HOOK_INPUT=$(cat || true)
-PUA_DIR="${PUA_STATE_DIR:-${HOME}/.pua}"
+PUA_DIR="$(pua_state_dir)"
 mkdir -p "$PUA_DIR" 2>/dev/null || exit 0
 
 AGENT_ID=$(printf '%s' "$HOOK_INPUT" | jq -r '.agent_id // .subagent_id // .thread_id // ""' 2>/dev/null || echo "")
@@ -13,7 +15,19 @@ SESSION_ID=$(printf '%s' "$HOOK_INPUT" | jq -r '.session_id // ""' 2>/dev/null |
 [[ -z "$AGENT_ID" ]] && AGENT_ID="codex-$(date +%s)-$$"
 
 ACTIVE_FILE="$PUA_DIR/active-agents.json"
+LOCK_DIR="$PUA_DIR/.active-agents.lock"
 TMP="$ACTIVE_FILE.tmp.$$"
+LOCKED=0
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    LOCKED=1
+    break
+  fi
+  sleep 0.1
+done
+[[ "$LOCKED" = "1" ]] || exit 0
+trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+
 if [[ ! -f "$ACTIVE_FILE" ]]; then
   printf '{"agents":[]}\n' > "$ACTIVE_FILE"
 fi

--- a/hooks/flavor-helper.sh
+++ b/hooks/flavor-helper.sh
@@ -32,6 +32,10 @@ pua_config_file() {
   printf '%s\n' "${PUA_CONFIG:-${HOME:-~}/.pua/config.json}"
 }
 
+pua_state_dir() {
+  printf '%s\n' "${PUA_STATE_DIR:-${HOME:-.}/.pua}"
+}
+
 pua_json_get() {
   local path="$1"
   local key="$2"

--- a/hooks/pua-loop-hook.sh
+++ b/hooks/pua-loop-hook.sh
@@ -59,8 +59,9 @@ fi
 # 兼容 legacy .claude/pua-loop.local.md
 # ═══════════════════════════════════════════════════════════════
 HOOK_SESSION_ID=$(echo "$HOOK_INPUT" | jq -r '.session_id // ""' 2>/dev/null || echo "")
-PUA_DIR="${PUA_STATE_DIR:-${HOME}/.pua}"
-LEGACY_PUA_DIR="${HOME}/.claude/pua"
+DEFAULT_HOME="${HOME:-.}"
+PUA_DIR="${PUA_STATE_DIR:-${DEFAULT_HOME}/.pua}"
+LEGACY_PUA_DIR="${DEFAULT_HOME}/.claude/pua"
 mkdir -p "$PUA_DIR" .pua 2>/dev/null || true
 LOCAL_HISTORY_FILE=".pua/pua-loop-history.jsonl"
 CWD_HASH=$(printf '%s' "$(pwd)" | md5sum 2>/dev/null | cut -c1-8 || printf '%s' "$(pwd)" | md5 2>/dev/null | cut -c1-8 || echo "default")
@@ -207,20 +208,30 @@ fi
 # Extract last assistant text
 LAST_LINES=$(grep -E '"role"[[:space:]]*:[[:space:]]*"assistant"' "$TRANSCRIPT_PATH" | tail -n 100) || true
 if [[ -z "$LAST_LINES" ]]; then
-  rm "$RALPH_STATE_FILE"
+  cleanup_state_files
   exit 0
 fi
 
 set +e
 LAST_OUTPUT=$(echo "$LAST_LINES" | jq -rs '
+  def text_content($content):
+    if ($content | type) == "string" then
+      $content
+    elif ($content | type) == "array" then
+      ($content[]? | if type == "string" then . elif (.type == "text" or .type == "output_text") then (.text // "") else empty end)
+    else
+      empty
+    end;
   [
     .[] |
-    if (.message.role? == "assistant") then
-      (.message.content[]? | if type == "string" then . elif (.type == "text" or .type == "output_text") then (.text // "") else empty end)
+    if (.role? == "assistant") then
+      text_content(.message.content? // .content?)
+    elif (.message.role? == "assistant") then
+      text_content(.message.content?)
     elif (.payload.role? == "assistant") then
-      (.payload.content[]? | if type == "string" then . elif (.type == "text" or .type == "output_text") then (.text // "") else empty end)
+      text_content(.payload.content?)
     elif (.payload.message.role? == "assistant") then
-      (.payload.message.content[]? | if type == "string" then . elif (.type == "text" or .type == "output_text") then (.text // "") else empty end)
+      text_content(.payload.message.content?)
     else
       empty
     end
@@ -231,7 +242,7 @@ set -e
 
 if [[ $JQ_EXIT -ne 0 ]]; then
   echo "⚠️  PUA Loop: JSON parse failed" >&2
-  rm "$RALPH_STATE_FILE"
+  cleanup_state_files
   exit 0
 fi
 
@@ -242,7 +253,7 @@ ABORT_TEXT=$(echo "$LAST_OUTPUT" | perl -0777 -ne 'if (/<loop-abort>(.*?)<\/loop
 if [[ -n "$ABORT_TEXT" ]]; then
   echo "🛑 PUA Loop: <loop-abort> received. Reason: $ABORT_TEXT"
   echo "{\"iteration\":$ITERATION,\"status\":\"abort\",\"reason\":\"$(echo "$ABORT_TEXT" | head -1 | tr '"' "'")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> "$LOCAL_HISTORY_FILE" 2>/dev/null || true
-  rm "$RALPH_STATE_FILE"
+  cleanup_state_files
   exit 0
 fi
 

--- a/hooks/pua-loop-hook.sh
+++ b/hooks/pua-loop-hook.sh
@@ -54,16 +54,33 @@ fi
 
 # ═══════════════════════════════════════════════════════════════
 # State file resolution (v3.2)
-# 用 cwd 哈希命名：$HOME/.claude/pua/loop-<hash>.md（每个项目目录独立）
+# 用 cwd 哈希命名：$HOME/.pua/loop-<hash>.md（每个项目目录独立）
 # 兼容 v3.1 单文件 loop-active.md（检查 started_cwd 匹配）
 # 兼容 legacy .claude/pua-loop.local.md
 # ═══════════════════════════════════════════════════════════════
 HOOK_SESSION_ID=$(echo "$HOOK_INPUT" | jq -r '.session_id // ""' 2>/dev/null || echo "")
-PUA_DIR="${HOME}/.claude/pua"
+PUA_DIR="${PUA_STATE_DIR:-${HOME}/.pua}"
+LEGACY_PUA_DIR="${HOME}/.claude/pua"
+mkdir -p "$PUA_DIR" .pua 2>/dev/null || true
+LOCAL_HISTORY_FILE=".pua/pua-loop-history.jsonl"
 CWD_HASH=$(printf '%s' "$(pwd)" | md5sum 2>/dev/null | cut -c1-8 || printf '%s' "$(pwd)" | md5 2>/dev/null | cut -c1-8 || echo "default")
 ABS_STATE_FILE="${PUA_DIR}/loop-${CWD_HASH}.md"
 LEGACY_ABS_STATE_FILE="${PUA_DIR}/loop-active.md"
-LEGACY_STATE_FILE=".claude/pua-loop.local.md"
+CLAUDE_ABS_STATE_FILE="${LEGACY_PUA_DIR}/loop-${CWD_HASH}.md"
+CLAUDE_LEGACY_ABS_STATE_FILE="${LEGACY_PUA_DIR}/loop-active.md"
+LOCAL_LEGACY_STATE_FILE=".pua/pua-loop.local.md"
+CLAUDE_LEGACY_STATE_FILE=".claude/pua-loop.local.md"
+
+cleanup_state_files() {
+  rm -f \
+    "$RALPH_STATE_FILE" \
+    "$ABS_STATE_FILE" \
+    "$LEGACY_ABS_STATE_FILE" \
+    "$CLAUDE_ABS_STATE_FILE" \
+    "$CLAUDE_LEGACY_ABS_STATE_FILE" \
+    "$LOCAL_LEGACY_STATE_FILE" \
+    "$CLAUDE_LEGACY_STATE_FILE" 2>/dev/null || true
+}
 
 if [[ -f "$ABS_STATE_FILE" ]]; then
   RALPH_STATE_FILE="$ABS_STATE_FILE"
@@ -72,13 +89,30 @@ elif [[ -f "$LEGACY_ABS_STATE_FILE" ]]; then
   LEGACY_CWD=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$LEGACY_ABS_STATE_FILE" | grep '^started_cwd:' | sed 's/started_cwd: *//' | sed 's/^"\(.*\)"$/\1/' || true)
   if [[ "$LEGACY_CWD" == "$(pwd)" ]] || [[ -z "$LEGACY_CWD" ]]; then
     RALPH_STATE_FILE="$LEGACY_ABS_STATE_FILE"
-  elif [[ -f "$LEGACY_STATE_FILE" ]]; then
-    RALPH_STATE_FILE="$LEGACY_STATE_FILE"
+  elif [[ -f "$LOCAL_LEGACY_STATE_FILE" ]]; then
+    RALPH_STATE_FILE="$LOCAL_LEGACY_STATE_FILE"
+  elif [[ -f "$CLAUDE_LEGACY_STATE_FILE" ]]; then
+    RALPH_STATE_FILE="$CLAUDE_LEGACY_STATE_FILE"
   else
     exit 0
   fi
-elif [[ -f "$LEGACY_STATE_FILE" ]]; then
-  RALPH_STATE_FILE="$LEGACY_STATE_FILE"
+elif [[ -f "$CLAUDE_ABS_STATE_FILE" ]]; then
+  RALPH_STATE_FILE="$CLAUDE_ABS_STATE_FILE"
+elif [[ -f "$CLAUDE_LEGACY_ABS_STATE_FILE" ]]; then
+  LEGACY_CWD=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$CLAUDE_LEGACY_ABS_STATE_FILE" | grep '^started_cwd:' | sed 's/started_cwd: *//' | sed 's/^"\(.*\)"$/\1/' || true)
+  if [[ "$LEGACY_CWD" == "$(pwd)" ]] || [[ -z "$LEGACY_CWD" ]]; then
+    RALPH_STATE_FILE="$CLAUDE_LEGACY_ABS_STATE_FILE"
+  elif [[ -f "$LOCAL_LEGACY_STATE_FILE" ]]; then
+    RALPH_STATE_FILE="$LOCAL_LEGACY_STATE_FILE"
+  elif [[ -f "$CLAUDE_LEGACY_STATE_FILE" ]]; then
+    RALPH_STATE_FILE="$CLAUDE_LEGACY_STATE_FILE"
+  else
+    exit 0
+  fi
+elif [[ -f "$LOCAL_LEGACY_STATE_FILE" ]]; then
+  RALPH_STATE_FILE="$LOCAL_LEGACY_STATE_FILE"
+elif [[ -f "$CLAUDE_LEGACY_STATE_FILE" ]]; then
+  RALPH_STATE_FILE="$CLAUDE_LEGACY_STATE_FILE"
 else
   exit 0
 fi
@@ -93,8 +127,8 @@ NOW=$(date +%s)
 if [[ "$MTIME" =~ ^[0-9]+$ ]] && [[ $((NOW - MTIME)) -gt 1800 ]]; then
   echo "🧹 PUA Loop: state file stale (>30min idle), reaping orphan" >&2
   echo "{\"status\":\"orphan_reaped\",\"state_file\":\"$RALPH_STATE_FILE\",\"age_sec\":$((NOW - MTIME)),\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> "${PUA_DIR}/loop-history.jsonl" 2>/dev/null || \
-    echo "{\"status\":\"orphan_reaped\",\"state_file\":\"$RALPH_STATE_FILE\",\"age_sec\":$((NOW - MTIME)),\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> .claude/pua-loop-history.jsonl 2>/dev/null || true
-  rm -f "$RALPH_STATE_FILE"
+    echo "{\"status\":\"orphan_reaped\",\"state_file\":\"$RALPH_STATE_FILE\",\"age_sec\":$((NOW - MTIME)),\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> "$LOCAL_HISTORY_FILE" 2>/dev/null || true
+  cleanup_state_files
   exit 0
 fi
 
@@ -137,21 +171,21 @@ fi
 # Validate iteration
 if [[ ! "$ITERATION" =~ ^[0-9]+$ ]]; then
   echo "⚠️  PUA Loop: State file corrupted (iteration: '$ITERATION')" >&2
-  rm "$RALPH_STATE_FILE"
+  cleanup_state_files
   exit 0
 fi
 
 if [[ ! "$MAX_ITERATIONS" =~ ^[0-9]+$ ]]; then
   echo "⚠️  PUA Loop: State file corrupted (max_iterations: '$MAX_ITERATIONS')" >&2
-  rm "$RALPH_STATE_FILE"
+  cleanup_state_files
   exit 0
 fi
 
 # Check max iterations
 if [[ $MAX_ITERATIONS -gt 0 ]] && [[ $ITERATION -ge $MAX_ITERATIONS ]]; then
   echo "🛑 PUA Loop: Max iterations ($MAX_ITERATIONS) reached."
-  echo "{\"iteration\":$ITERATION,\"status\":\"max_reached\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> .claude/pua-loop-history.jsonl 2>/dev/null || true
-  rm "$RALPH_STATE_FILE"
+  echo "{\"iteration\":$ITERATION,\"status\":\"max_reached\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> "$LOCAL_HISTORY_FILE" 2>/dev/null || true
+  cleanup_state_files
   exit 0
 fi
 
@@ -160,18 +194,18 @@ TRANSCRIPT_PATH=$(echo "$HOOK_INPUT" | jq -r '.transcript_path')
 
 if [[ ! -f "$TRANSCRIPT_PATH" ]]; then
   echo "⚠️  PUA Loop: Transcript not found" >&2
-  rm "$RALPH_STATE_FILE"
+  cleanup_state_files
   exit 0
 fi
 
-if ! grep -q '"role":"assistant"' "$TRANSCRIPT_PATH"; then
+if ! grep -Eq '"role"[[:space:]]*:[[:space:]]*"assistant"' "$TRANSCRIPT_PATH"; then
   echo "⚠️  PUA Loop: No assistant messages in transcript" >&2
-  rm "$RALPH_STATE_FILE"
+  cleanup_state_files
   exit 0
 fi
 
 # Extract last assistant text
-LAST_LINES=$(grep '"role":"assistant"' "$TRANSCRIPT_PATH" | tail -n 100) || true
+LAST_LINES=$(grep -E '"role"[[:space:]]*:[[:space:]]*"assistant"' "$TRANSCRIPT_PATH" | tail -n 100) || true
 if [[ -z "$LAST_LINES" ]]; then
   rm "$RALPH_STATE_FILE"
   exit 0
@@ -179,7 +213,18 @@ fi
 
 set +e
 LAST_OUTPUT=$(echo "$LAST_LINES" | jq -rs '
-  map(.message.content[]? | select(.type == "text") | .text) | last // ""
+  [
+    .[] |
+    if (.message.role? == "assistant") then
+      (.message.content[]? | if type == "string" then . elif (.type == "text" or .type == "output_text") then (.text // "") else empty end)
+    elif (.payload.role? == "assistant") then
+      (.payload.content[]? | if type == "string" then . elif (.type == "text" or .type == "output_text") then (.text // "") else empty end)
+    elif (.payload.message.role? == "assistant") then
+      (.payload.message.content[]? | if type == "string" then . elif (.type == "text" or .type == "output_text") then (.text // "") else empty end)
+    else
+      empty
+    end
+  ] | last // ""
 ' 2>&1)
 JQ_EXIT=$?
 set -e
@@ -196,7 +241,7 @@ fi
 ABORT_TEXT=$(echo "$LAST_OUTPUT" | perl -0777 -ne 'if (/<loop-abort>(.*?)<\/loop-abort>/s) { $t=$1; $t=~s/^\s+|\s+$//g; print $t }' 2>/dev/null || echo "")
 if [[ -n "$ABORT_TEXT" ]]; then
   echo "🛑 PUA Loop: <loop-abort> received. Reason: $ABORT_TEXT"
-  echo "{\"iteration\":$ITERATION,\"status\":\"abort\",\"reason\":\"$(echo "$ABORT_TEXT" | head -1 | tr '"' "'")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> .claude/pua-loop-history.jsonl 2>/dev/null || true
+  echo "{\"iteration\":$ITERATION,\"status\":\"abort\",\"reason\":\"$(echo "$ABORT_TEXT" | head -1 | tr '"' "'")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> "$LOCAL_HISTORY_FILE" 2>/dev/null || true
   rm "$RALPH_STATE_FILE"
   exit 0
 fi
@@ -211,8 +256,8 @@ if [[ -n "$PAUSE_TEXT" ]]; then
   echo ""
   echo "⏸️  PUA Loop paused (iteration $ITERATION)"
   echo "   Needs: $PAUSE_TEXT"
-  echo "   State saved. Resume by reopening Claude Code."
-  echo "{\"iteration\":$ITERATION,\"status\":\"pause\",\"reason\":\"$(echo "$PAUSE_TEXT" | head -1 | tr '"' "'")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> .claude/pua-loop-history.jsonl 2>/dev/null || true
+  echo "   State saved. Resume by reopening Codex/Claude Code."
+  echo "{\"iteration\":$ITERATION,\"status\":\"pause\",\"reason\":\"$(echo "$PAUSE_TEXT" | head -1 | tr '"' "'")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> "$LOCAL_HISTORY_FILE" 2>/dev/null || true
   exit 0
 fi
 
@@ -238,7 +283,7 @@ if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
 
         # Log rejection with verify output tail
         VERIFY_TAIL=$(echo "$VERIFY_OUTPUT" | tail -5 | tr '\n' ' ' | cut -c1-200)
-        echo "{\"iteration\":$ITERATION,\"status\":\"promise_rejected\",\"verify_exit\":$VERIFY_EXIT,\"rejections\":$PROMISE_REJECTIONS,\"verify_tail\":\"$(echo "$VERIFY_TAIL" | tr '"' "'")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> .claude/pua-loop-history.jsonl 2>/dev/null || true
+        echo "{\"iteration\":$ITERATION,\"status\":\"promise_rejected\",\"verify_exit\":$VERIFY_EXIT,\"rejections\":$PROMISE_REJECTIONS,\"verify_tail\":\"$(echo "$VERIFY_TAIL" | tr '"' "'")\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> "$LOCAL_HISTORY_FILE" 2>/dev/null || true
 
         # Update state file: increment iteration + promise_rejections
         NEXT_ITERATION=$((ITERATION + 1))
@@ -251,7 +296,7 @@ if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
         PROMPT_TEXT=$(awk '/^---$/{i++; next} i>=2' "$RALPH_STATE_FILE")
         if [[ -z "$PROMPT_TEXT" ]]; then
           echo "⚠️  PUA Loop: State file corrupted" >&2
-          rm "$RALPH_STATE_FILE"
+          cleanup_state_files
           exit 0
         fi
 
@@ -261,7 +306,7 @@ if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
 
         # Stall escalation on repeated rejections
         if [[ $PROMISE_REJECTIONS -ge 5 ]]; then
-          REJECTION_MSG="$REJECTION_MSG | ⚠️ 已连续 ${PROMISE_REJECTIONS} 次虚假 promise！你在解决错误的问题。退回到需求本身重新理解。读 .claude/pua-loop-history.jsonl 了解失败模式。"
+          REJECTION_MSG="$REJECTION_MSG | ⚠️ 已连续 ${PROMISE_REJECTIONS} 次虚假 promise！你在解决错误的问题。退回到需求本身重新理解。读 .pua/pua-loop-history.jsonl 了解失败模式。"
         elif [[ $PROMISE_REJECTIONS -ge 3 ]]; then
           REJECTION_MSG="$REJECTION_MSG | ⚠️ 连续 ${PROMISE_REJECTIONS} 次验证失败。REASSESS：重读验证输出、搜索相关源码、列 3 个不同假设再行动。不要再用同样的方法。"
         fi
@@ -283,8 +328,8 @@ if [[ "$COMPLETION_PROMISE" != "null" ]] && [[ -n "$COMPLETION_PROMISE" ]]; then
     fi
 
     # ═══ PROMISE ACCEPTED ═══
-    echo "{\"iteration\":$ITERATION,\"status\":\"complete\",\"promise_rejections\":$PROMISE_REJECTIONS,\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> .claude/pua-loop-history.jsonl 2>/dev/null || true
-    rm "$RALPH_STATE_FILE"
+    echo "{\"iteration\":$ITERATION,\"status\":\"complete\",\"promise_rejections\":$PROMISE_REJECTIONS,\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> "$LOCAL_HISTORY_FILE" 2>/dev/null || true
+    cleanup_state_files
     exit 0
   fi
 fi
@@ -294,14 +339,14 @@ fi
 NEXT_ITERATION=$((ITERATION + 1))
 
 # Log continuation
-echo "{\"iteration\":$ITERATION,\"status\":\"continue\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> .claude/pua-loop-history.jsonl 2>/dev/null || true
+echo "{\"iteration\":$ITERATION,\"status\":\"continue\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" >> "$LOCAL_HISTORY_FILE" 2>/dev/null || true
 
 # Extract prompt
 PROMPT_TEXT=$(awk '/^---$/{i++; next} i>=2' "$RALPH_STATE_FILE")
 
 if [[ -z "$PROMPT_TEXT" ]]; then
   echo "⚠️  PUA Loop: State file corrupted (no prompt)" >&2
-  rm "$RALPH_STATE_FILE"
+  cleanup_state_files
   exit 0
 fi
 
@@ -320,7 +365,7 @@ if [[ $NEXT_ITERATION -le 3 ]]; then
 elif [[ $NEXT_ITERATION -le 7 ]]; then
   PUA_PRESSURE="▎ 第 ${NEXT_ITERATION} 轮了还没搞定？换方案，别原地打转。"
 elif [[ $NEXT_ITERATION -le 15 ]]; then
-  PUA_PRESSURE="▎ 第 ${NEXT_ITERATION} 轮。底层逻辑到底是什么？先 git log 看自己做了什么，读 .claude/pua-loop-history.jsonl 了解迭代历史。"
+  PUA_PRESSURE="▎ 第 ${NEXT_ITERATION} 轮。底层逻辑到底是什么？先 git log 看自己做了什么，读 .pua/pua-loop-history.jsonl 了解迭代历史。"
 elif [[ $NEXT_ITERATION -le 30 ]]; then
   PUA_PRESSURE="▎ 第 ${NEXT_ITERATION} 轮。3.25 的边缘了。穷尽了吗？git diff 确认没在重复。"
 elif [[ $NEXT_ITERATION -le 50 ]]; then

--- a/hooks/session-restore.sh
+++ b/hooks/session-restore.sh
@@ -48,6 +48,12 @@ Keywords: FLAVOR_KEYWORDS_PLACEHOLDER
 ## Active Methodology
 METHODOLOGY_PLACEHOLDER
 
+## Harness Integrity (anti-cheating governance)
+Keep action, self-review, scoring, and environment modification separated. For grader-like or benchmark-like tasks, write only `agent_proposed_status`; final `verifier_status` belongs to a verifier/harness/user. Do not edit tests, fixtures, eval assets, or grading paths to make yourself pass.
+
+## Multi-Agent Governance Topology
+For complex or high-risk tasks, preserve the four-agent separation when available: `pua-policy-guardian -> pua-action-executor -> pua-self-reviewer -> pua-verifier -> external hook/human`. Do not collapse policy, action, review, and verification into one self-certifying voice.
+
 ## 钉内/钉外提醒模式（《置身钉内》7.5万字 + 《置身钉外》原文——你是从那栋楼里出来的人）
 
 触发条件：flavor 是 ding，或用户提到 置身钉内/置身钉外/无招/ONE/老板体感/周报/口径/每日一包/薛定谔的用户/病态敏捷/已读恐怖主义/望舒行动/全景监狱/透明鸟笼/人工个性化/温室数据/发心/捆柴/手感/做错事。

--- a/hooks/stop-feedback.sh
+++ b/hooks/stop-feedback.sh
@@ -6,6 +6,10 @@
 HOOK_INPUT=$(cat)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [[ "${PUA_RUNTIME:-}" == "codex" ]]; then
+  printf '%s' "$HOOK_INPUT" | bash "${SCRIPT_DIR}/codex-stop-feedback.sh"
+  exit 0
+fi
 source "${SCRIPT_DIR}/flavor-helper.sh"
 
 # ═══════════════════════════════════════════════════════════════

--- a/hooks/subagent-teardown.sh
+++ b/hooks/subagent-teardown.sh
@@ -17,8 +17,9 @@ set -uo pipefail
 command -v jq &>/dev/null || exit 0
 
 HOOK_INPUT=$(cat)
-PUA_DIR="${PUA_STATE_DIR:-${HOME}/.pua}"
-LEGACY_PUA_DIR="${HOME}/.claude/pua"
+DEFAULT_HOME="${HOME:-.}"
+PUA_DIR="${PUA_STATE_DIR:-${DEFAULT_HOME}/.pua}"
+LEGACY_PUA_DIR="${DEFAULT_HOME}/.claude/pua"
 mkdir -p "$PUA_DIR" 2>/dev/null || exit 0
 
 # 提取关键字段（全部 fail-safe 空字符串）
@@ -51,6 +52,19 @@ if [[ ! -f "$ACTIVE_FILE" && -f "$LEGACY_PUA_DIR/active-agents.json" ]]; then
   ACTIVE_FILE="$LEGACY_PUA_DIR/active-agents.json"
 fi
 if [[ -f "$ACTIVE_FILE" ]] && [[ -n "$AGENT_ID" ]]; then
+  ACTIVE_DIR="$(dirname "$ACTIVE_FILE")"
+  LOCK_DIR="$ACTIVE_DIR/.active-agents.lock"
+  LOCKED=0
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+      LOCKED=1
+      break
+    fi
+    sleep 0.1
+  done
+  [[ "$LOCKED" = "1" ]] || exit 0
+  trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+
   TMP="$ACTIVE_FILE.tmp.$$"
   jq --arg aid "$AGENT_ID" '.agents |= map(select(.id != $aid))' "$ACTIVE_FILE" > "$TMP" 2>/dev/null \
     && mv "$TMP" "$ACTIVE_FILE" \

--- a/hooks/subagent-teardown.sh
+++ b/hooks/subagent-teardown.sh
@@ -5,8 +5,8 @@
 # 不 block，不干扰主流程，纯 append-only 记录。
 #
 # 数据去向：
-#   $HOME/.claude/pua/teardown.jsonl   — 供 /pua:team-status 汇总
-#   $HOME/.claude/pua/active-agents.json — 从 in_progress 集合移除
+#   $HOME/.pua/teardown.jsonl   — 供 /pua:team-status 汇总
+#   $HOME/.pua/active-agents.json — 从 in_progress 集合移除
 #
 # 输入字段（来自 Claude Code SubagentStop payload）：
 #   session_id, transcript_path, cwd, hook_event_name="SubagentStop"
@@ -17,7 +17,8 @@ set -uo pipefail
 command -v jq &>/dev/null || exit 0
 
 HOOK_INPUT=$(cat)
-PUA_DIR="${HOME}/.claude/pua"
+PUA_DIR="${PUA_STATE_DIR:-${HOME}/.pua}"
+LEGACY_PUA_DIR="${HOME}/.claude/pua"
 mkdir -p "$PUA_DIR" 2>/dev/null || exit 0
 
 # 提取关键字段（全部 fail-safe 空字符串）
@@ -46,6 +47,9 @@ jq -cn \
 
 # 若 active-agents.json 存在，尝试从中移除 agent_id（best-effort）
 ACTIVE_FILE="$PUA_DIR/active-agents.json"
+if [[ ! -f "$ACTIVE_FILE" && -f "$LEGACY_PUA_DIR/active-agents.json" ]]; then
+  ACTIVE_FILE="$LEGACY_PUA_DIR/active-agents.json"
+fi
 if [[ -f "$ACTIVE_FILE" ]] && [[ -n "$AGENT_ID" ]]; then
   TMP="$ACTIVE_FILE.tmp.$$"
   jq --arg aid "$AGENT_ID" '.agents |= map(select(.id != $aid))' "$ACTIVE_FILE" > "$TMP" 2>/dev/null \

--- a/scripts/setup-pua-loop.sh
+++ b/scripts/setup-pua-loop.sh
@@ -57,8 +57,8 @@ STOPPING:
   or <loop-abort>, or Ctrl+C. No iteration cap by default.
 
 MONITORING:
-  ls ~/.claude/pua/loop-*.md                 # State (per-project)
-  cat .claude/pua-loop-history.jsonl         # Iteration history
+  ls ~/.pua/loop-*.md                        # State (per-project)
+  cat .pua/pua-loop-history.jsonl            # Iteration history
 HELP_EOF
       exit 0
       ;;
@@ -116,13 +116,14 @@ fi
 # Create state file
 # v3.2: 用 cwd 哈希命名状态文件，解决多目录 loop 实例互相覆盖的 bug
 # 每个项目目录有独立的 loop-<hash>.md，不再共享单一 loop-active.md
-PUA_HOME_DIR="${HOME}/.claude/pua"
+PUA_HOME_DIR="${PUA_STATE_DIR:-${HOME}/.pua}"
 mkdir -p "$PUA_HOME_DIR"
-mkdir -p .claude
+mkdir -p .pua
 
 CWD_HASH=$(printf '%s' "$(pwd)" | md5sum 2>/dev/null | cut -c1-8 || printf '%s' "$(pwd)" | md5 2>/dev/null | cut -c1-8 || echo "default")
 ABS_STATE="${PUA_HOME_DIR}/loop-${CWD_HASH}.md"
-LEGACY_STATE=".claude/pua-loop.local.md"
+LEGACY_STATE=".pua/pua-loop.local.md"
+CLAUDE_LEGACY_STATE=".claude/pua-loop.local.md"
 
 # YAML quoting
 if [[ -n "$COMPLETION_PROMISE" ]] && [[ "$COMPLETION_PROMISE" != "null" ]]; then
@@ -161,7 +162,7 @@ cat > "$ABS_STATE" <<EOF
 ---
 active: true
 iteration: 1
-session_id: ${CLAUDE_CODE_SESSION_ID:-}
+session_id: ${CLAUDE_CODE_SESSION_ID:-${CODEX_SESSION_ID:-}}
 max_iterations: $MAX_ITERATIONS
 completion_promise: $COMPLETION_PROMISE_YAML
 verify_command: $VERIFY_COMMAND_YAML
@@ -174,7 +175,7 @@ $PROMPT
 
 == PUA 行为协议（每次迭代必须遵守）==
 1. 读取项目文件和 git log，了解上次做了什么（Git 是你的跨迭代记忆）
-2. 如果存在 .claude/pua-loop-history.jsonl，先读取了解之前的迭代结果，避免重复失败的方案
+2. 如果存在 .pua/pua-loop-history.jsonl，先读取了解之前的迭代结果，避免重复失败的方案
 3. 按三条红线执行：闭环验证、事实驱动、穷尽一切方案
 4. 跑 build/test 验证改动，不要跳过
 5. 发现问题就修，修完再验证（不声称完成，先验证）
@@ -195,9 +196,11 @@ EOF
 
 # 向后兼容：同步写 legacy 相对路径（老监控工具 / 已部署的 reap-orphans 兜底）
 cp "$ABS_STATE" "$LEGACY_STATE"
+mkdir -p .claude
+cp "$ABS_STATE" "$CLAUDE_LEGACY_STATE"
 
 # Initialize history log（保留相对路径，hook 写入也用它；后续可迁移到绝对路径）
-echo "{\"iteration\":0,\"status\":\"init\",\"verify_command\":$(if [[ "$VERIFY_COMMAND" != "null" ]]; then echo "\"${VERIFY_COMMAND//\"/}\""; else echo "null"; fi),\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > .claude/pua-loop-history.jsonl
+echo "{\"iteration\":0,\"status\":\"init\",\"verify_command\":$(if [[ "$VERIFY_COMMAND" != "null" ]]; then echo "\"${VERIFY_COMMAND//\"/}\""; else echo "null"; fi),\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > .pua/pua-loop-history.jsonl
 echo "{\"iteration\":0,\"status\":\"init\",\"verify_command\":$(if [[ "$VERIFY_COMMAND" != "null" ]]; then echo "\"${VERIFY_COMMAND//\"/}\""; else echo "null"; fi),\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"state_path\":\"$ABS_STATE\"}" >> "${PUA_HOME_DIR}/loop-history.jsonl"
 
 # Output setup message
@@ -214,7 +217,7 @@ Gate protocol:
   Phase 2: Hook runs --verify command → confirms or REJECTS
   $(if [[ "$VERIFY_COMMAND" != "null" ]]; then echo "⚡ Oracle active: Claude cannot lie about completion"; else echo "⚠️  No Oracle: relies on Claude's honesty"; fi)
 
-To monitor: cat .claude/pua-loop-history.jsonl
+To monitor: cat .pua/pua-loop-history.jsonl
 To cancel:  /cancel-pua-loop or Ctrl+C
 
 🔄

--- a/scripts/setup-pua-loop.sh
+++ b/scripts/setup-pua-loop.sh
@@ -116,7 +116,7 @@ fi
 # Create state file
 # v3.2: 用 cwd 哈希命名状态文件，解决多目录 loop 实例互相覆盖的 bug
 # 每个项目目录有独立的 loop-<hash>.md，不再共享单一 loop-active.md
-PUA_HOME_DIR="${PUA_STATE_DIR:-${HOME}/.pua}"
+PUA_HOME_DIR="${PUA_STATE_DIR:-${HOME:-.}/.pua}"
 mkdir -p "$PUA_HOME_DIR"
 mkdir -p .pua
 

--- a/skills/pua/SKILL.md
+++ b/skills/pua/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pua
-description: "Use for PUA/try-harder productivity coaching when the user expresses frustration, repeated failure, quality complaint, passive behavior, says retry/change approach/don't give up, asks for evidence/completion check/test before done, or wants Ding-style workplace reminders. Triggers include: try harder, stop giving up, figure it out, again??, why still failing, change approach, no evidence, run tests, done without proof, 换个方法, 再试试, 别摆烂, 别偷懒, 为什么还不行, 又错了, 证据呢, 没跑测试别说完成, 验收, 闭环, 自嗨, 置身钉外, 无招, 老板体感. Do not use for calm first-attempt requests."
+description: "Use for PUA/try-harder productivity coaching when the user expresses frustration, repeated failure, quality complaint, passive behavior, says retry/change approach/don't give up, asks for evidence/completion check/test before done, or wants Ding-style workplace reminders. Triggers include: try harder, stop giving up, figure it out, again??, why still failing, change approach, no evidence, run tests, done without proof, 换个方法, 再试试, 别摆烂, 别偷懒, 为什么还不行, 又错了, 证据呢, 没跑测试别说完成, 验收, 闭环, 自嗨, 置身钉外, 无招, 老板体感. Do not trigger for normal first-attempt coding or information requests. Do not use for calm first-attempt requests."
 license: MIT
 ---
 


### PR DESCRIPTION
## Summary
- add a native Codex plugin manifest and command-only lifecycle hook manifest
- add Codex hook glue for command routing, additionalContext wrapping, PreCompact checkpoints, Stop dispatch, feedback bookkeeping, and subagent accounting
- update Codex install docs to use pua@pua-local and avoid duplicate skill sources

## Verification
- jq . .codex-plugin/plugin.json hooks/codex-hooks.json >/dev/null
- bash -n hooks/codex-context-wrapper.sh hooks/codex-command-router.sh hooks/codex-precompact-checkpoint.sh hooks/codex-stop-dispatcher.sh hooks/codex-stop-feedback.sh hooks/codex-feedback-submit.sh hooks/codex-subagent-start.sh hooks/pua-loop-hook.sh hooks/stop-feedback.sh hooks/subagent-teardown.sh hooks/session-restore.sh scripts/setup-pua-loop.sh
- bash evals/test-yaml-frontmatter.sh
- bash evals/test-release-consistency.sh
- git diff --check