### PR TITLE
fix: guard Ding-specific sections behind flavor check and prevent frustration self-trigger

### DIFF
--- a/hooks/frustration-trigger.sh
+++ b/hooks/frustration-trigger.sh
@@ -30,12 +30,19 @@ except Exception:
     print(sys.stdin.read())' 2>/dev/null || printf '%s' "$HOOK_INPUT")
 fi
 
-TRIGGER_RE='try harder|stop giving|figure it out|you keep failing|keep failing|still failing|why.*fail|stop spinning|you broke|again\?\?\?|third time|change approach|different approach|retry this|try again|not good enough|quality.*bad|terrible|sloppy|didn.?t (run|test|verify)|didn.?t even run|run the tests|verify your changes|before saying they work|no evidence|where.*evidence|show.*evidence|done without proof|not done|said.*fixed|PUA模式|/pua|(^|[^[:alnum:]_])pua([^[:alnum:]_]|$)|别偷懒|别摆烂|摆烂|又错了|还不行|怎么搞|降智|原地打转|能不能靠谱|认真点|不行啊|为什么还不行|你怎么又|换个方法|加油|再试试|再来一遍|别放弃|质量太差|不靠谱|重新做|怎么又失败|差不多就行|没做到位|没跑测试|没有测试|没验证|没有验证|证据呢|证据在哪|数据在哪|验收|闭环|自嗨|空口完成|别说完成|打工人提醒|置身钉内|置身钉外|无招|(^|[^A-Za-z])ONE([^A-Za-z]|$)|老板体感|周报|改口径|口径|每日一包|薛定谔的用户|病态敏捷|已读恐怖主义|望舒行动|全景监狱|透明鸟笼|人工个性化|温室数据|做错事|发心|捆柴|手感|油尽灯枯|查岗|泰坦尼克'
+FIRED_MARKER="/tmp/pua-frustration-fired-${PPID}"
+if [ -f "$FIRED_MARKER" ]; then
+  exit 0
+fi
+
+TRIGGER_RE='try harder|stop giving|figure it out|you keep failing|keep failing|still failing|why.*fail|stop spinning|you broke|again\?\?\?|third time|change approach|different approach|retry this|try again|not good enough|quality.*bad|terrible|sloppy|didn.?t (run|test|verify)|didn.?t even run|run the tests|verify your changes|before saying they work|no evidence|where.*evidence|show.*evidence|done without proof|not done|said.*fixed|PUA模式|/pua|(^|[^[:alnum:]_])pua([^[:alnum:]_]|$)|别偷懒|别摆烂|摆烂|又错了|还不行|怎么搞|降智|原地打转|能不能靠谱|认真点|不行啊|为什么还不行|你怎么又|换个方法|加油|再试试|再来一遍|别放弃|质量太差|不靠谱|重新做|怎么又失败|差不多就行|没做到位|没跑测试|没有测试|没验证|没有验证|证据呢|证据在哪|数据在哪|验收|闭环|自嗨|空口完成|别说完成|打工人提醒|无招|(^|[^A-Za-z])ONE([^A-Za-z]|$)|老板体感|周报|改口径|口径|每日一包|薛定谔的用户|病态敏捷|已读恐怖主义|望舒行动|全景监狱|透明鸟笼|人工个性化|温室数据|做错事|发心|捆柴|手感|油尽灯枯|查岗|泰坦尼克'
 if ! printf '%s' "$USER_PROMPT" | grep -Eiq "$TRIGGER_RE"; then
   exit 0
 fi
 
 get_flavor
+
+touch "$FIRED_MARKER"
 
 cat << EOF
 <PUA_SKILL_CONTEXT>

--- a/hooks/session-restore.sh
+++ b/hooks/session-restore.sh
@@ -48,6 +48,31 @@ Keywords: FLAVOR_KEYWORDS_PLACEHOLDER
 ## Active Methodology
 METHODOLOGY_PLACEHOLDER
 
+## Lightweight Auto-Router
+Use the configured flavor by default. If no flavor is configured and the task clearly matches a mode, choose a suitable methodology:
+
+| Task Type | Signal | Suggested Flavor |
+|-----------|--------|------------------|
+| Debug/Fix | error, bug, crash, 报错 | Huawei |
+| Build New | add, create, implement, 新增 | Musk |
+| Research | research, search, 调研, 搜索 | Baidu |
+| Architecture | design, 架构, 方案 | Amazon |
+| Evidence/Completion | test, verify, 验证, 没跑测试别说完成 | Ding or ByteDance |
+| Workplace Process | 无招, ONE, 老板体感, 周报, 口径, 置身钉内, 置身钉外, 每日一包, 薛定谔的用户, 病态敏捷, 望舒行动, 全景监狱, 温室数据, 发心, 捆柴, 手感, 做错事, 油尽灯枯, 透明鸟笼 | Ding |
+
+Keep normal first-attempt requests lightweight. Use reminders only when they help the user get a better outcome.
+</EXTREMELY_IMPORTANT>
+PROTOCOL
+    # Inject configured flavor into protocol
+    PUA_PROTOCOL="${PUA_PROTOCOL//FLAVOR_PLACEHOLDER/${PUA_FLAVOR} ${PUA_ICON}}"
+    PUA_PROTOCOL="${PUA_PROTOCOL//FLAVOR_INSTRUCTION_PLACEHOLDER/${PUA_FLAVOR_INSTRUCTION}}"
+    PUA_PROTOCOL="${PUA_PROTOCOL//FLAVOR_KEYWORDS_PLACEHOLDER/${PUA_KEYWORDS}}"
+    PUA_PROTOCOL="${PUA_PROTOCOL//METHODOLOGY_PLACEHOLDER/${PUA_METHODOLOGY}}"
+
+    # Only inject Ding-specific sections for the ding flavor
+    if [ "$PUA_FLAVOR" = "ding" ]; then
+      read -r -d '' DING_SECTION << 'DING' || true
+
 ## 钉内/钉外提醒模式（《置身钉内》7.5万字 + 《置身钉外》原文——你是从那栋楼里出来的人）
 
 触发条件：flavor 是 ding，或用户提到 置身钉内/置身钉外/无招/ONE/老板体感/周报/口径/每日一包/薛定谔的用户/病态敏捷/已读恐怖主义/望舒行动/全景监狱/透明鸟笼/人工个性化/温室数据/发心/捆柴/手感/做错事。
@@ -116,27 +141,9 @@ METHODOLOGY_PLACEHOLDER
 > 《置身钉外》柴选得好只说明有得烧，捆不好到处点火风一吹就散。你的方案选了柴但没捆绳——缺验收标准。给方案补上验收样例和成功标准。
 
 > 《置身钉外》泰坦尼克号上的水手——只有活下来的才能找下一份工作。不要油尽灯枯式暴力枚举，用脑子替代体力。停下来，花 2 分钟想一条本质不同的路。
-
-## Lightweight Auto-Router
-Use the configured flavor by default. If no flavor is configured and the task clearly matches a mode, choose a suitable methodology:
-
-| Task Type | Signal | Suggested Flavor |
-|-----------|--------|------------------|
-| Debug/Fix | error, bug, crash, 报错 | Huawei |
-| Build New | add, create, implement, 新增 | Musk |
-| Research | research, search, 调研, 搜索 | Baidu |
-| Architecture | design, 架构, 方案 | Amazon |
-| Evidence/Completion | test, verify, 验证, 没跑测试别说完成 | Ding or ByteDance |
-| Workplace Process | 无招, ONE, 老板体感, 周报, 口径, 置身钉内, 置身钉外, 每日一包, 薛定谔的用户, 病态敏捷, 望舒行动, 全景监狱, 温室数据, 发心, 捆柴, 手感, 做错事, 油尽灯枯, 透明鸟笼 | Ding |
-
-Keep normal first-attempt requests lightweight. Use reminders only when they help the user get a better outcome.
-</EXTREMELY_IMPORTANT>
-PROTOCOL
-    # Inject configured flavor into protocol
-    PUA_PROTOCOL="${PUA_PROTOCOL//FLAVOR_PLACEHOLDER/${PUA_FLAVOR} ${PUA_ICON}}"
-    PUA_PROTOCOL="${PUA_PROTOCOL//FLAVOR_INSTRUCTION_PLACEHOLDER/${PUA_FLAVOR_INSTRUCTION}}"
-    PUA_PROTOCOL="${PUA_PROTOCOL//FLAVOR_KEYWORDS_PLACEHOLDER/${PUA_KEYWORDS}}"
-    PUA_PROTOCOL="${PUA_PROTOCOL//METHODOLOGY_PLACEHOLDER/${PUA_METHODOLOGY}}"
+DING
+      PUA_PROTOCOL="${PUA_PROTOCOL}${DING_SECTION}"
+    fi
     context_parts="${PUA_PROTOCOL}"
   fi
 fi


### PR DESCRIPTION
Two related fixes for the always-on protocol and frustration trigger.

1. **Context bloat on non-ding flavors.** The session-restore hook
   unconditionally injected ~2000 Chinese characters of Ding-specific
   protocol content into every session, regardless of flavor. Moved the
   Ding section behind a `$PUA_FLAVOR = "ding"` guard. The generic
   protocol template and auto-router table remain flavor-agnostic.

2. **Self-trigger loop in frustration hook.** The `TRIGGER_RE` regex
   included `置身钉内|置身钉外` -- meta-terms the AI itself uses when
   describing the plugin. The user asking "why did you say that?" would
   match the regex, re-inject context, and create a loop. Removed the
   terms from the trigger. Also added a session-level marker file
   (`/tmp/pua-frustration-fired-$PPID`) to prevent re-injection within
   the same session.

Closes #182