### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,7 +766,7 @@ ls ~/.codex/sessions/*.jsonl
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tanweai/pua&type=Date)](https://star-history.com/#tanweai/pua&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=tanweai/pua&type=Date)](https://star-history.dera.page/#tanweai/pua&Date)
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -727,7 +727,7 @@ ls ~/.codex/sessions/*.jsonl
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tanweai/pua&type=Date)](https://star-history.com/#tanweai/pua&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=tanweai/pua&type=Date)](https://star-history.dera.page/#tanweai/pua&Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart on this repository is currently broken and no longer renders because of GitHub stargazer API restrictions. This change points the chart to a working data source so it displays correctly again. Updated in both the English and Chinese READMEs.